### PR TITLE
Let's collaborate to make tomlj better

### DIFF
--- a/src/main/antlr/org/tomlj/internal/TomlLexer.g4
+++ b/src/main/antlr/org/tomlj/internal/TomlLexer.g4
@@ -125,7 +125,7 @@ ValueError : . -> type(Error), popMode;
 mode BasicStringMode;
 
 BasicStringEnd : '"' -> type(QuotationMark), popMode;
-BasicStringUnescaped : ~[\u0000-\u0008\u000A-\u001F\u007F] -> type(StringChar);
+BasicStringUnescaped : ~[\u0000-\u0008\u000A-\u001F"\\\u007F] -> type(StringChar);
 EscapeSequence
   : '\\' ~[\n]
   | '\\u' HexDig HexDig HexDig HexDig
@@ -137,9 +137,9 @@ BasicStringError : . -> type(Error), popMode;
 
 mode MLBasicStringMode;
 
-MLBasicStringEnd : '"""' -> type(TripleQuotationMark), popMode;
+MLBasicStringEnd : '""' -> type(TripleQuotationMark), popMode;
 MLBasicStringLineEnd : '\\' [ \t]* NL { setText(System.lineSeparator()); } -> type(NewLine);
-MLBasicStringUnescaped : ~[\u0000-\u0008\u000C\u000E-\u001F\u007F] -> type(StringChar);
+MLBasicStringUnescaped : ~[\u0000-\u0008\u000C\u000E-\u001F\\\u007F] -> type(StringChar);
 MLBasicStringEscape :
   ('\\u' HexDig HexDig HexDig HexDig
   | '\\U' HexDig HexDig HexDig HexDig HexDig HexDig HexDig HexDig

--- a/src/main/antlr/org/tomlj/internal/TomlLexer.g4
+++ b/src/main/antlr/org/tomlj/internal/TomlLexer.g4
@@ -137,7 +137,7 @@ BasicStringError : . -> type(Error), popMode;
 
 mode MLBasicStringMode;
 
-MLBasicStringEnd : '""' -> type(TripleQuotationMark), popMode;
+MLBasicStringEnd : '"""' -> type(TripleQuotationMark), popMode;
 MLBasicStringLineEnd : '\\' [ \t]* NL { setText(System.lineSeparator()); } -> type(NewLine);
 MLBasicStringUnescaped : ~[\u0000-\u0008\u000C\u000E-\u001F\\\u007F] -> type(StringChar);
 MLBasicStringEscape :

--- a/src/main/java/org/tomlj/JSONArray.java
+++ b/src/main/java/org/tomlj/JSONArray.java
@@ -1,0 +1,111 @@
+package org.tomlj;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class JSONArray implements Iterable<Object> {
+
+    /**
+     * The arrayList where the JSONArray's properties are kept.
+     */
+    private final ArrayList<Object> myArrayList;
+
+    /**
+     * Construct an empty JSONArray.
+     */
+    public JSONArray() {
+        this.myArrayList = new ArrayList<Object>();
+    }
+
+    /**
+     * Construct a JSONArray from a JSONTokener.
+     *
+     * @param x A JSONTokener
+     * @throws JSONException If there is a syntax error.
+     */
+    public JSONArray(JSONTokener x) throws JSONException {
+        this();
+        if (x.nextClean() != '[') {
+            throw x.syntaxError("A JSONArray text must start with '['");
+        }
+        
+        char nextChar = x.nextClean();
+        if (nextChar == 0) {
+            // array is unclosed. No ']' found, instead EOF
+            throw x.syntaxError("Expected a ',' or ']'");
+        }
+        if (nextChar != ']') {
+            x.back();
+            for (;;) {
+                if (x.nextClean() == ',') {
+                    x.back();
+                    this.myArrayList.add(JSONObject.NULL);
+                } else {
+                    x.back();
+                    this.myArrayList.add(x.nextValue());
+                }
+                switch (x.nextClean()) {
+                case 0:
+                    // array is unclosed. No ']' found, instead EOF
+                    throw x.syntaxError("Expected a ',' or ']'");
+                case ',':
+                    nextChar = x.nextClean();
+                    if (nextChar == 0) {
+                        // array is unclosed. No ']' found, instead EOF
+                        throw x.syntaxError("Expected a ',' or ']'");
+                    }
+                    if (nextChar == ']') {
+                        return;
+                    }
+                    x.back();
+                    break;
+                case ']':
+                    return;
+                default:
+                    throw x.syntaxError("Expected a ',' or ']'");
+                }
+            }
+        }
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+        return this.myArrayList.iterator();
+    }
+
+    /**
+     * Get the object value associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return An object value.
+     * @throws JSONException
+     *             If there is no value for the index.
+     */
+    public Object get(int index) throws JSONException {
+        Object object = this.opt(index);
+        if (object == null) {
+            throw new JSONException("JSONArray[" + index + "] not found.");
+        }
+        return object;
+    }
+
+    /**
+     * Get the number of elements in the JSONArray, included nulls.
+     *
+     * @return The length (or size).
+     */
+    public int length() {
+        return this.myArrayList.size();
+    }
+
+    /**
+     * Get the optional object value associated with an index.
+     *
+     * @param index The index must be between 0 and length() - 1. If not, null is returned.
+     * @return An object value, or null if there is no object at that index.
+     */
+    public Object opt(int index) {
+        return (index < 0 || index >= this.length()) ? null : this.myArrayList.get(index);
+    }
+}

--- a/src/main/java/org/tomlj/JSONException.java
+++ b/src/main/java/org/tomlj/JSONException.java
@@ -1,0 +1,28 @@
+package org.tomlj;
+
+@SuppressWarnings("serial")
+public class JSONException extends RuntimeException {
+
+    public JSONException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a JSONException with an explanatory message and cause.
+     * 
+     * @param message Detail about the reason for the exception.
+     * @param cause The cause.
+     */
+    public JSONException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new JSONException with the specified cause.
+     * 
+     * @param cause The cause.
+     */
+    public JSONException(final Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+}

--- a/src/main/java/org/tomlj/JSONObject.java
+++ b/src/main/java/org/tomlj/JSONObject.java
@@ -1,0 +1,376 @@
+package org.tomlj;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class JSONObject {
+
+    private static final class Null {}
+    
+    /**
+     * The map where the JSONObject's properties are kept.
+     */
+    private final Map<String, Object> map;
+
+    /**
+     * It is sometimes more convenient and less ambiguous to have a
+     * <code>NULL</code> object than to use Java's <code>null</code> value.
+     * <code>JSONObject.NULL.equals(null)</code> returns <code>true</code>.
+     * <code>JSONObject.NULL.toString()</code> returns <code>"null"</code>.
+     */
+    public static final Object NULL = new Null();
+
+    /**
+     * Construct an empty JSONObject.
+     */
+    public JSONObject() {
+        this.map = new LinkedHashMap<String, Object>();
+    }
+
+    /**
+     * Construct a JSONObject from a JSONTokener.
+     *
+     * @param x A JSONTokener object containing the source string.
+     * @throws JSONException If there is a syntax error in the source 
+     * string or a duplicated key.
+     */
+    public JSONObject(JSONTokener x) throws JSONException {
+        this();
+        char c;
+        String key;
+
+        if (x.nextClean() != '{') {
+            throw x.syntaxError("A JSONObject text must begin with '{'");
+        }
+        for (;;) {
+            c = x.nextClean();
+            switch (c) {
+            case 0:
+                throw x.syntaxError("A JSONObject text must end with '}'");
+            case '}':
+                return;
+            default:
+                x.back();
+                key = x.nextValue().toString();
+            }
+
+            // The key is followed by ':'.
+
+            c = x.nextClean();
+            if (c != ':') {
+                throw x.syntaxError("Expected a ':' after a key");
+            }
+            
+            // Use syntaxError(..) to include error location
+            
+            if (key != null) {
+                // Check if key exists
+                if (this.opt(key) != null) {
+                    // key already exists
+                    throw x.syntaxError("Duplicate key \"" + key + "\"");
+                }
+                // Only add value if non-null
+                Object value = x.nextValue();
+                if (value!=null) {
+                    this.put(key, value);
+                }
+            }
+
+            // Pairs are separated by ','.
+
+            switch (x.nextClean()) {
+            case ';':
+            case ',':
+                if (x.nextClean() == '}') {
+                    return;
+                }
+                x.back();
+                break;
+            case '}':
+                return;
+            default:
+                throw x.syntaxError("Expected a ',' or '}'");
+            }
+        }
+    }
+
+    /**
+     * Construct a JSONObject from a source JSON text string. This is the most
+     * commonly used JSONObject constructor.
+     *
+     * @param source
+     *            A string beginning with <code>{</code>&nbsp;<small>(left
+     *            brace)</small> and ending with <code>}</code>
+     *            &nbsp;<small>(right brace)</small>.
+     * @exception JSONException
+     *                If there is a syntax error in the source string or a
+     *                duplicated key.
+     */
+    public JSONObject(String source) throws JSONException {
+        this(new JSONTokener(source));
+    }
+
+    /**
+     * Get the value object associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The object associated with the key.
+     * @throws JSONException
+     *             if the key is not found.
+     */
+    public Object get(String key) throws JSONException {
+        if (key == null) {
+            throw new JSONException("Null key.");
+        }
+        Object object = this.opt(key);
+        if (object == null) {
+            throw new JSONException("JSONObject[" + quote(key) + "] not found.");
+        }
+        return object;
+    }
+
+    /**
+     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also
+     * modify the JSONObject. Use with caution.
+     * 
+     * @return An iterator of the keys.
+     */
+    public Iterator<String> keys() {
+        return this.keySet().iterator();
+    }
+
+    /**
+     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the
+     * JSONObject. Use with caution.
+     *
+     * @return A keySet.
+     */
+    public Set<String> keySet() {
+        return this.map.keySet();
+    }
+
+    /**
+     * Get an optional value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return An object which is the value, or null if there is no value.
+     */
+    public Object opt(String key) {
+        return key == null ? null : this.map.get(key);
+    }
+
+    /**
+     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the
+     * key will be removed from the JSONObject if it is present.
+     *
+     * @param key A key string.
+     * @param value An object which is the value. It should be of one of these
+     *              types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
+     *              String, or the JSONObject.NULL object.
+     * @return this.
+     * @throws JSONException If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, Object value) throws JSONException {
+        if (key == null) {
+            throw new NullPointerException("Null key.");
+        }
+        if (value != null) {
+            testValidity(value);
+            this.map.put(key, value);
+        } else {
+            this.remove(key);
+        }
+        return this;
+    }
+
+    /**
+     * Produce a string in double quotes with backslash sequences in all the
+     * right places. A backslash will be inserted within &lt;/, producing
+     * &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a
+     * string cannot contain a control character or an unescaped quote or
+     * backslash.
+     *
+     * @param string
+     *            A String
+     * @return A String correctly formatted for insertion in a JSON text.
+     */
+    public static String quote(String string) {
+        StringWriter sw = new StringWriter();
+        synchronized (sw.getBuffer()) {
+            try {
+                return quote(string, sw).toString();
+            } catch (IOException ignored) {
+                // will never happen - we are writing to a string writer
+                return "";
+            }
+        }
+    }
+
+    public static Writer quote(String string, Writer w) throws IOException {
+        if (string == null || string.isEmpty()) {
+            w.write("\"\"");
+            return w;
+        }
+
+        char b;
+        char c = 0;
+        String hhhh;
+        int i;
+        int len = string.length();
+
+        w.write('"');
+        for (i = 0; i < len; i += 1) {
+            b = c;
+            c = string.charAt(i);
+            switch (c) {
+            case '\\':
+            case '"':
+                w.write('\\');
+                w.write(c);
+                break;
+            case '/':
+                if (b == '<') {
+                    w.write('\\');
+                }
+                w.write(c);
+                break;
+            case '\b':
+                w.write("\\b");
+                break;
+            case '\t':
+                w.write("\\t");
+                break;
+            case '\n':
+                w.write("\\n");
+                break;
+            case '\f':
+                w.write("\\f");
+                break;
+            case '\r':
+                w.write("\\r");
+                break;
+            default:
+                if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
+                        || (c >= '\u2000' && c < '\u2100')) {
+                    w.write("\\u");
+                    hhhh = Integer.toHexString(c);
+                    w.write("0000", 0, 4 - hhhh.length());
+                    w.write(hhhh);
+                } else {
+                    w.write(c);
+                }
+            }
+        }
+        w.write('"');
+        return w;
+    }
+
+    /**
+     * Remove a name and its value, if present.
+     *
+     * @param key
+     *            The name to be removed.
+     * @return The value that was associated with the name, or null if there was
+     *         no value.
+     */
+    public Object remove(String key) {
+        return this.map.remove(key);
+    }
+
+    /**
+     * Tests if the value should be tried as a decimal. It makes no test if there are actual digits.
+     * 
+     * @param val value to test
+     * @return true if the string is "-0" or if it contains '.', 'e', or 'E', false otherwise.
+     */
+    protected static boolean isDecimalNotation(final String val) {
+        return val.indexOf('.') > -1 || val.indexOf('e') > -1
+                || val.indexOf('E') > -1 || "-0".equals(val);
+    }
+    
+    /**
+     * Try to convert a string into a number, boolean, or null. If the string
+     * can't be converted, return the string.
+     *
+     * @param string
+     *            A String. can not be null.
+     * @return A simple JSON value.
+     * @throws NullPointerException
+     *             Thrown if the string is null.
+     */
+    // Changes to this method must be copied to the corresponding method in
+    // the XML class to keep full support for Android
+    public static Object stringToValue(String string) {
+        if ("".equals(string)) {
+            return string;
+        }
+
+        // check JSON key words true/false/null
+        if ("true".equalsIgnoreCase(string)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(string)) {
+            return Boolean.FALSE;
+        }
+        if ("null".equalsIgnoreCase(string)) {
+            return JSONObject.NULL;
+        }
+
+        /*
+         * If it might be a number, try converting it. If a number cannot be
+         * produced, then the value will just be a string.
+         */
+
+        char initial = string.charAt(0);
+        if ((initial >= '0' && initial <= '9') || initial == '-') {
+            try {
+                if (isDecimalNotation(string)) {
+                    Double d = Double.valueOf(string);
+                    if (!d.isInfinite() && !d.isNaN()) {
+                        return d;
+                    }
+                } else {
+                    Long myLong = Long.valueOf(string);
+                    if (string.equals(myLong.toString())) {
+                        if (myLong.longValue() == myLong.intValue()) {
+                            return Integer.valueOf(myLong.intValue());
+                        }
+                        return myLong;
+                    }
+                }
+            } catch (Exception ignore) {
+            }
+        }
+        return string;
+    }
+
+    /**
+     * Throw an exception if the object is a NaN or infinite number.
+     *
+     * @param o The object to test.
+     * @throws JSONException If o is a non-finite number.
+     */
+    public static void testValidity(Object o) throws JSONException {
+        if (o != null) {
+            if (o instanceof Double) {
+                if (((Double) o).isInfinite() || ((Double) o).isNaN()) {
+                    throw new JSONException(
+                            "JSON does not allow non-finite numbers.");
+                }
+            } else if (o instanceof Float) {
+                if (((Float) o).isInfinite() || ((Float) o).isNaN()) {
+                    throw new JSONException(
+                            "JSON does not allow non-finite numbers.");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/tomlj/JSONPath.java
+++ b/src/main/java/org/tomlj/JSONPath.java
@@ -1,0 +1,58 @@
+package org.tomlj;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+public class JSONPath {
+
+    private static LinkedHashMap<String, Object> map;
+    
+	public static void validateJSON(String json) {
+        new JSONObject(json);
+    }
+    
+	public static LinkedHashMap<String, Object> setJsonPaths(String json) {
+        map = new LinkedHashMap<String, Object>();
+        JSONObject object = new JSONObject(json);
+        String jsonPath = "$";
+        if(json != JSONObject.NULL) {
+            readObject(object, jsonPath);
+        }
+        return map;
+    }
+
+    private static void readObject(JSONObject object, String jsonPath) {
+        Iterator<String> keysItr = object.keys();
+        String parentPath = jsonPath;
+        while(keysItr.hasNext()) {
+            String key = keysItr.next();
+            Object value = object.get(key);
+            jsonPath = parentPath + "." + "[" + key + "]";
+
+            if(value instanceof JSONArray) {            
+                readArray((JSONArray) value, jsonPath);
+            }
+            else if(value instanceof JSONObject) {
+                readObject((JSONObject) value, jsonPath);
+            } else {
+            	map.put(jsonPath, value);    
+            }          
+        }  
+    }
+
+    private static void readArray(JSONArray array, String jsonPath) {      
+        String parentPath = jsonPath;
+        for(int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);        
+            jsonPath = parentPath + "[" + i + "]";
+
+            if(value instanceof JSONArray) {
+                readArray((JSONArray) value, jsonPath);
+            } else if(value instanceof JSONObject) {                
+                readObject((JSONObject) value, jsonPath);
+            } else {
+            	map.put(jsonPath, value);
+            }
+        }
+    }
+}

--- a/src/main/java/org/tomlj/JSONTokener.java
+++ b/src/main/java/org/tomlj/JSONTokener.java
@@ -1,0 +1,478 @@
+package org.tomlj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+
+/**
+ * A JSONTokener takes a source string and extracts characters and tokens from
+ * it. It is used by the JSONObject and JSONArray constructors to parse
+ * JSON source strings.
+ * @author JSON.org
+ * @version 2014-05-03
+ */
+public class JSONTokener {
+    /** current read character position on the current line. */
+    private long character;
+    /** flag to indicate if the end of the input has been found. */
+    private boolean eof;
+    /** current read index of the input. */
+    private long index;
+    /** current line of the input. */
+    private long line;
+    /** previous character read from the input. */
+    private char previous;
+    /** Reader for the input. */
+    private final Reader reader;
+    /** flag to indicate that a previous character was requested. */
+    private boolean usePrevious;
+    /** the number of characters read in the previous line. */
+    private long characterPreviousLine;
+
+
+    /**
+     * Construct a JSONTokener from a Reader. The caller must close the Reader.
+     *
+     * @param reader     A reader.
+     */
+    public JSONTokener(Reader reader) {
+        this.reader = reader.markSupported()
+                ? reader
+                        : new BufferedReader(reader);
+        this.eof = false;
+        this.usePrevious = false;
+        this.previous = 0;
+        this.index = 0;
+        this.character = 1;
+        this.characterPreviousLine = 0;
+        this.line = 1;
+    }
+
+
+    /**
+     * Construct a JSONTokener from a string.
+     *
+     * @param s     A source string.
+     */
+    public JSONTokener(String s) {
+        this(new StringReader(s));
+    }
+
+
+    /**
+     * Back up one character. This provides a sort of lookahead capability,
+     * so that you can test for a digit or letter before attempting to parse
+     * the next number or identifier.
+     * @throws JSONException Thrown if trying to step back more than 1 step
+     *  or if already at the start of the string
+     */
+    public void back() throws JSONException {
+        if (this.usePrevious || this.index <= 0) {
+            throw new JSONException("Stepping back two steps is not supported");
+        }
+        this.decrementIndexes();
+        this.usePrevious = true;
+        this.eof = false;
+    }
+
+    /**
+     * Decrements the indexes for the {@link #back()} method based on the previous character read.
+     */
+    private void decrementIndexes() {
+        this.index--;
+        if(this.previous=='\r' || this.previous == '\n') {
+            this.line--;
+            this.character=this.characterPreviousLine ;
+        } else if(this.character > 0){
+            this.character--;
+        }
+    }
+
+
+    /**
+     * Checks if the end of the input has been reached.
+     *  
+     * @return true if at the end of the file and we didn't step back
+     */
+    public boolean end() {
+        return this.eof && !this.usePrevious;
+    }
+
+
+    /**
+     * Determine if the source string still contains characters that next()
+     * can consume.
+     * @return true if not yet at the end of the source.
+     * @throws JSONException thrown if there is an error stepping forward
+     *  or backward while checking for more data.
+     */
+    public boolean more() throws JSONException {
+        if(this.usePrevious) {
+            return true;
+        }
+        try {
+            this.reader.mark(1);
+        } catch (IOException e) {
+            throw new JSONException("Unable to preserve stream position", e);
+        }
+        try {
+            // -1 is EOF, but next() can not consume the null character '\0'
+            if(this.reader.read() <= 0) {
+                this.eof = true;
+                return false;
+            }
+            this.reader.reset();
+        } catch (IOException e) {
+            throw new JSONException("Unable to read the next character from the stream", e);
+        }
+        return true;
+    }
+
+
+    /**
+     * Get the next character in the source string.
+     *
+     * @return The next character, or 0 if past the end of the source string.
+     * @throws JSONException Thrown if there is an error reading the source string.
+     */
+    public char next() throws JSONException {
+        int c;
+        if (this.usePrevious) {
+            this.usePrevious = false;
+            c = this.previous;
+        } else {
+            try {
+                c = this.reader.read();
+            } catch (IOException exception) {
+                throw new JSONException(exception);
+            }
+        }
+        if (c <= 0) { // End of stream
+            this.eof = true;
+            return 0;
+        }
+        this.incrementIndexes(c);
+        this.previous = (char) c;
+        return this.previous;
+    }
+
+    /**
+     * Increments the internal indexes according to the previous character
+     * read and the character passed as the current character.
+     * @param c the current character read.
+     */
+    private void incrementIndexes(int c) {
+        if(c > 0) {
+            this.index++;
+            if(c=='\r') {
+                this.line++;
+                this.characterPreviousLine = this.character;
+                this.character=0;
+            }else if (c=='\n') {
+                if(this.previous != '\r') {
+                    this.line++;
+                    this.characterPreviousLine = this.character;
+                }
+                this.character=0;
+            } else {
+                this.character++;
+            }
+        }
+    }
+
+    /**
+     * Consume the next character, and check that it matches a specified
+     * character.
+     * @param c The character to match.
+     * @return The character.
+     * @throws JSONException if the character does not match.
+     */
+    public char next(char c) throws JSONException {
+        char n = this.next();
+        if (n != c) {
+            if(n > 0) {
+                throw this.syntaxError("Expected '" + c + "' and instead saw '" +
+                        n + "'");
+            }
+            throw this.syntaxError("Expected '" + c + "' and instead saw ''");
+        }
+        return n;
+    }
+
+
+    /**
+     * Get the next n characters.
+     *
+     * @param n     The number of characters to take.
+     * @return      A string of n characters.
+     * @throws JSONException
+     *   Substring bounds error if there are not
+     *   n characters remaining in the source string.
+     */
+    public String next(int n) throws JSONException {
+        if (n == 0) {
+            return "";
+        }
+
+        char[] chars = new char[n];
+        int pos = 0;
+
+        while (pos < n) {
+            chars[pos] = this.next();
+            if (this.end()) {
+                throw this.syntaxError("Substring bounds error");
+            }
+            pos += 1;
+        }
+        return new String(chars);
+    }
+
+
+    /**
+     * Get the next char in the string, skipping whitespace.
+     * @throws JSONException Thrown if there is an error reading the source string.
+     * @return  A character, or 0 if there are no more characters.
+     */
+    public char nextClean() throws JSONException {
+        for (;;) {
+            char c = this.next();
+            if (c == 0 || c > ' ') {
+                return c;
+            }
+        }
+    }
+
+
+    /**
+     * Return the characters up to the next close quote character.
+     * Backslash processing is done. The formal JSON format does not
+     * allow strings in single quotes, but an implementation is allowed to
+     * accept them.
+     * @param quote The quoting character, either
+     *      <code>"</code>&nbsp;<small>(double quote)</small> or
+     *      <code>'</code>&nbsp;<small>(single quote)</small>.
+     * @return      A String.
+     * @throws JSONException Unterminated string.
+     */
+    public String nextString(char quote) throws JSONException {
+        char c;
+        StringBuilder sb = new StringBuilder();
+        for (;;) {
+            c = this.next();
+            switch (c) {
+            case 0:
+            case '\n':
+            case '\r':
+                throw this.syntaxError("Unterminated string");
+            case '\\':
+                c = this.next();
+                switch (c) {
+                case 'b':
+                    sb.append('\b');
+                    break;
+                case 't':
+                    sb.append('\t');
+                    break;
+                case 'n':
+                    sb.append('\n');
+                    break;
+                case 'f':
+                    sb.append('\f');
+                    break;
+                case 'r':
+                    sb.append('\r');
+                    break;
+                case 'u':
+                    try {
+                        sb.append((char)Integer.parseInt(this.next(4), 16));
+                    } catch (NumberFormatException e) {
+                        throw this.syntaxError("Illegal escape.", e);
+                    }
+                    break;
+                case '"':
+                case '\'':
+                case '\\':
+                case '/':
+                    sb.append(c);
+                    break;
+                default:
+                    throw this.syntaxError("Illegal escape.");
+                }
+                break;
+            default:
+                if (c == quote) {
+                    return sb.toString();
+                }
+                sb.append(c);
+            }
+        }
+    }
+
+
+    /**
+     * Get the text up but not including the specified character or the
+     * end of line, whichever comes first.
+     * @param  delimiter A delimiter character.
+     * @return   A string.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the delimiter
+     */
+    public String nextTo(char delimiter) throws JSONException {
+        StringBuilder sb = new StringBuilder();
+        for (;;) {
+            char c = this.next();
+            if (c == delimiter || c == 0 || c == '\n' || c == '\r') {
+                if (c != 0) {
+                    this.back();
+                }
+                return sb.toString().trim();
+            }
+            sb.append(c);
+        }
+    }
+
+
+    /**
+     * Get the text up but not including one of the specified delimiter
+     * characters or the end of line, whichever comes first.
+     * @param delimiters A set of delimiter characters.
+     * @return A string, trimmed.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the delimiter
+     */
+    public String nextTo(String delimiters) throws JSONException {
+        char c;
+        StringBuilder sb = new StringBuilder();
+        for (;;) {
+            c = this.next();
+            if (delimiters.indexOf(c) >= 0 || c == 0 ||
+                    c == '\n' || c == '\r') {
+                if (c != 0) {
+                    this.back();
+                }
+                return sb.toString().trim();
+            }
+            sb.append(c);
+        }
+    }
+
+
+    /**
+     * Get the next value. The value can be a Boolean, Double, Integer,
+     * JSONArray, JSONObject, Long, or String, or the JSONObject.NULL object.
+     * @throws JSONException If syntax error.
+     *
+     * @return An object.
+     */
+    public Object nextValue() throws JSONException {
+        char c = this.nextClean();
+        String string;
+
+        switch (c) {
+        case '"':
+        case '\'':
+            return this.nextString(c);
+        case '{':
+            this.back();
+            return new JSONObject(this);
+        case '[':
+            this.back();
+            return new JSONArray(this);
+        }
+
+        /*
+         * Handle unquoted text. This could be the values true, false, or
+         * null, or it can be a number. An implementation (such as this one)
+         * is allowed to also accept non-standard forms.
+         *
+         * Accumulate characters until we reach the end of the text or a
+         * formatting character.
+         */
+
+        StringBuilder sb = new StringBuilder();
+        while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
+            sb.append(c);
+            c = this.next();
+        }
+        if (!this.eof) {
+            this.back();
+        }
+
+        string = sb.toString().trim();
+        if ("".equals(string)) {
+            throw this.syntaxError("Missing value");
+        }
+        return JSONObject.stringToValue(string);
+    }
+
+
+    /**
+     * Skip characters until the next character is the requested character.
+     * If the requested character is not found, no characters are skipped.
+     * @param to A character to skip to.
+     * @return The requested character, or zero if the requested character
+     * is not found.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the to character
+     */
+    public char skipTo(char to) throws JSONException {
+        char c;
+        try {
+            long startIndex = this.index;
+            long startCharacter = this.character;
+            long startLine = this.line;
+            this.reader.mark(1000000);
+            do {
+                c = this.next();
+                if (c == 0) {
+                    // in some readers, reset() may throw an exception if
+                    // the remaining portion of the input is greater than
+                    // the mark size (1,000,000 above).
+                    this.reader.reset();
+                    this.index = startIndex;
+                    this.character = startCharacter;
+                    this.line = startLine;
+                    return 0;
+                }
+            } while (c != to);
+            this.reader.mark(1);
+        } catch (IOException exception) {
+            throw new JSONException(exception);
+        }
+        this.back();
+        return c;
+    }
+
+    /**
+     * Make a JSONException to signal a syntax error.
+     *
+     * @param message The error message.
+     * @return  A JSONException object, suitable for throwing
+     */
+    public JSONException syntaxError(String message) {
+        return new JSONException(message + this.toString());
+    }
+
+    /**
+     * Make a JSONException to signal a syntax error.
+     *
+     * @param message The error message.
+     * @param causedBy The throwable that caused the error.
+     * @return  A JSONException object, suitable for throwing
+     */
+    public JSONException syntaxError(String message, Throwable causedBy) {
+        return new JSONException(message + this.toString(), causedBy);
+    }
+
+    /**
+     * Make a printable string of this JSONTokener.
+     *
+     * @return " at {index} [character {character} line {line}]"
+     */
+    @Override
+    public String toString() {
+        return " at " + this.index + " [character " + this.character + " line " + this.line + "]";
+    }
+}

--- a/src/main/java/org/tomlj/JsonSerializer.java
+++ b/src/main/java/org/tomlj/JsonSerializer.java
@@ -135,20 +135,17 @@ final class JsonSerializer {
 		for (int i = 0; i < text.length(); i++) {
 			char ch = text.charAt(i);
 			if (ch == '\"') {
-				out.append('\\');
-				out.append('\"');
+				out.append("\\\"");
 				continue;
 			}
 			if (ch == '\\') {
-			    out.append('\\');
-			    out.append('\\');
+			    out.append("\\\\");
 			    continue;
 			}
 			if (ch >= 0x20) {
 				out.append(ch);
 				continue;
 			}
-
 			switch (ch) {
 			case '\t':
 				out.append("\\t");

--- a/src/main/java/org/tomlj/JsonSerializer.java
+++ b/src/main/java/org/tomlj/JsonSerializer.java
@@ -24,41 +24,45 @@ final class JsonSerializer {
 	private JsonSerializer() {
 	}
 
-	static void toJson(TomlTable table, Appendable appendable) throws IOException {
+	static void toJson(TomlTable table, Appendable appendable, Integer... optionalIndent) throws IOException {
+		Integer optIndent = ((optionalIndent.length > 0) ? (Integer)optionalIndent[0] : 2);
 		requireNonNull(table);
 		requireNonNull(appendable);
-		toJson(table, appendable, 0);
-		appendable.append(System.lineSeparator());
+		toJson(table, appendable, 0, optionalIndent);
+		if(optIndent > 0) {appendable.append(System.lineSeparator());}
 	}
 
-	private static void toJson(TomlTable table, Appendable appendable, int indent) throws IOException {
+	private static void toJson(TomlTable table, Appendable appendable, int indent, Integer... optionalIndent) throws IOException {
+		Integer optIndent = ((optionalIndent.length > 0) ? (Integer)optionalIndent[0] : 2);
 		if (table.isEmpty()) {
 			appendable.append("{}");
 			return;
 		}
-		appendLine(appendable, "{");
+		appendLine(appendable, "{", optIndent);
 		for (Iterator<Map.Entry<String, Object>> iterator = table.entrySet().stream().iterator(); iterator.hasNext();) {
 			Map.Entry<String, Object> entry = iterator.next();
 			String key = entry.getKey();
-			append(appendable, indent + 4, "\"" + escape(key) + "\": ");
+			append(appendable, indent + optIndent , "\"" + escape(key) + "\": ");
 			Object value = entry.getValue();
 			assert value != null;
-			appendTomlValue(value, appendable, indent);
+			appendTomlValue(value, appendable, indent, optionalIndent);
 			if (iterator.hasNext()) {
 				appendable.append(",");
-				appendable.append(System.lineSeparator());
+				if(optIndent > 0) {appendable.append(System.lineSeparator());}
 			}
 		}
-		appendable.append(System.lineSeparator());
+		if(optIndent > 0) {appendable.append(System.lineSeparator());}
 		append(appendable, indent, "}");
 	}
 
-	static void toJson(TomlArray array, Appendable appendable) throws IOException {
-		toJson(array, appendable, 0);
-		appendable.append(System.lineSeparator());
+	static void toJson(TomlArray array, Appendable appendable, Integer... optionalIndent) throws IOException {
+		Integer optIndent = ((optionalIndent.length > 0) ? (Integer)optionalIndent[0] : 2);
+		toJson(array, appendable, 0, optionalIndent);
+		if(optIndent > 0) {appendable.append(System.lineSeparator());}
 	}
 
-	private static void toJson(TomlArray array, Appendable appendable, int indent) throws IOException {
+	private static void toJson(TomlArray array, Appendable appendable, int indent, Integer... optionalIndent) throws IOException {
+		Integer optIndent = ((optionalIndent.length > 0) ? (Integer)optionalIndent[0] : 2);
 		if (array.isEmpty()) {
 			appendable.append("[]");
 			return;
@@ -66,28 +70,29 @@ final class JsonSerializer {
 		if (array.containsTables()) {
 			append(appendable, 0, "[");
 			for (Iterator<Object> iterator = array.toList().iterator(); iterator.hasNext();) {
-				toJson((TomlTable) iterator.next(), appendable, indent);
+				toJson((TomlTable) iterator.next(), appendable, indent, optionalIndent);
 				if (iterator.hasNext()) {
 					appendable.append(",");
 				}
 			}
 			append(appendable, 0, "]");
 		} else {
-			appendLine(appendable, "[");
+			appendLine(appendable, "[", optIndent);
 			for (Iterator<Object> iterator = array.toList().iterator(); iterator.hasNext();) {
-				indentLine(appendable, indent + 4);
-				appendTomlValue(iterator.next(), appendable, indent);
+				indentLine(appendable, indent + optIndent);
+				appendTomlValue(iterator.next(), appendable, indent, optionalIndent);
 				if (iterator.hasNext()) {
 					appendable.append(",");
-					appendable.append(System.lineSeparator());
+					if(optIndent > 0) {appendable.append(System.lineSeparator());}
 				}
 			}
-			appendable.append(System.lineSeparator());
+			if(optIndent > 0) {appendable.append(System.lineSeparator());}
 			append(appendable, indent, "]");
 		}
 	}
 
-	private static void appendTomlValue(Object value, Appendable appendable, int indent) throws IOException {
+	private static void appendTomlValue(Object value, Appendable appendable, int indent, Integer... optionalIndent) throws IOException {
+		Integer optIndent = ((optionalIndent.length > 0) ? (Integer)optionalIndent[0] : 2);
 		Optional<TomlType> tomlType = typeFor(value);
 		assert tomlType.isPresent();
 		switch (tomlType.get()) {
@@ -108,10 +113,10 @@ final class JsonSerializer {
 			append(appendable, 0, "\"" + value.toString() + "\"");
 			break;
 		case ARRAY:
-			toJson((TomlArray) value, appendable, indent + 4);
+			toJson((TomlArray) value, appendable, indent + optIndent, optionalIndent);
 			break;
 		case TABLE:
-			toJson((TomlTable) value, appendable, indent + 4);
+			toJson((TomlTable) value, appendable, indent + optIndent, optionalIndent);
 			break;
 		}
 	}
@@ -121,9 +126,10 @@ final class JsonSerializer {
 		appendable.append(line);
 	}
 
-	private static void appendLine(Appendable appendable, String line) throws IOException {
+	private static void appendLine(Appendable appendable, String line, Integer... optionalIndent) throws IOException {
+		Integer optIndent = ((optionalIndent.length > 0) ? (Integer)optionalIndent[0] : 2);
 		appendable.append(line);
-		appendable.append(System.lineSeparator());
+		if(optIndent > 0) {appendable.append(System.lineSeparator());}
 	}
 
 	private static void indentLine(Appendable appendable, int indent) throws IOException {

--- a/src/main/java/org/tomlj/JsonSerializer.java
+++ b/src/main/java/org/tomlj/JsonSerializer.java
@@ -23,146 +23,152 @@ import java.util.Optional;
 final class JsonSerializer {
   private JsonSerializer() {}
 
-  static void toJson(TomlTable table, Appendable appendable) throws IOException {
-    requireNonNull(table);
-    requireNonNull(appendable);
-    toJson(table, appendable, 0);
-    appendable.append(System.lineSeparator());
-  }
+	static void toJson(TomlTable table, Appendable appendable) throws IOException {
+		requireNonNull(table);
+		requireNonNull(appendable);
+		toJson(table, appendable, 0);
+		appendable.append(System.lineSeparator());
+	}
 
-  private static void toJson(TomlTable table, Appendable appendable, int indent) throws IOException {
-    if (table.isEmpty()) {
-      appendable.append("{}");
-      return;
-    }
-    appendLine(appendable, "{");
-    for (Iterator<String> iterator = table.keySet().stream().sorted().iterator(); iterator.hasNext();) {
-      String key = iterator.next();
-      append(appendable, indent + 2, "\"" + escape(key) + "\" : ");
-      Object value = table.get(Collections.singletonList(key));
-      assert value != null;
-      appendTomlValue(value, appendable, indent);
-      if (iterator.hasNext()) {
-        appendable.append(",");
-        appendable.append(System.lineSeparator());
-      }
-    }
-    appendable.append(System.lineSeparator());
-    append(appendable, indent, "}");
-  }
+	private static void toJson(TomlTable table, Appendable appendable, int indent) throws IOException {
+		if (table.isEmpty()) {
+			appendable.append("{}");
+			return;
+		}
+		appendLine(appendable, "{");
+		for (Iterator<String> iterator = table.keySet().iterator(); iterator.hasNext();) {
+			String key = iterator.next();
+			append(appendable, indent + 4, "\"" + escape(key) + "\": ");
+			Object value = table.get(Collections.singletonList(key));
+			assert value != null;
+			appendTomlValue(value, appendable, indent);
+			if (iterator.hasNext()) {
+				appendable.append(",");
+				appendable.append(System.lineSeparator());
+			}
+		}
+		appendable.append(System.lineSeparator());
+		append(appendable, indent, "}");
+	}
 
-  static void toJson(TomlArray array, Appendable appendable) throws IOException {
-    toJson(array, appendable, 0);
-    appendable.append(System.lineSeparator());
-  }
+	static void toJson(TomlArray array, Appendable appendable) throws IOException {
+		toJson(array, appendable, 0);
+		appendable.append(System.lineSeparator());
+	}
 
-  private static void toJson(TomlArray array, Appendable appendable, int indent) throws IOException {
-    if (array.isEmpty()) {
-      appendable.append("[]");
-      return;
-    }
-    if (array.containsTables()) {
-      append(appendable, 0, "[");
-      for (Iterator<Object> iterator = array.toList().iterator(); iterator.hasNext();) {
-        toJson((TomlTable) iterator.next(), appendable, indent);
-        if (iterator.hasNext()) {
-          appendable.append(",");
-        }
-      }
-      append(appendable, 0, "]");
-    } else {
-      appendLine(appendable, "[");
-      for (Iterator<Object> iterator = array.toList().iterator(); iterator.hasNext();) {
-        indentLine(appendable, indent + 2);
-        appendTomlValue(iterator.next(), appendable, indent);
-        if (iterator.hasNext()) {
-          appendable.append(",");
-          appendable.append(System.lineSeparator());
-        }
-      }
-      appendable.append(System.lineSeparator());
-      append(appendable, indent, "]");
-    }
-  }
+	private static void toJson(TomlArray array, Appendable appendable, int indent) throws IOException {
+		if (array.isEmpty()) {
+			appendable.append("[]");
+			return;
+		}
+		if (array.containsTables()) {
+			append(appendable, 0, "[");
+			for (Iterator<Object> iterator = array.toList().iterator(); iterator.hasNext();) {
+				toJson((TomlTable) iterator.next(), appendable, indent);
+				if (iterator.hasNext()) {
+					appendable.append(",");
+				}
+			}
+			append(appendable, 0, "]");
+		} else {
+			appendLine(appendable, "[");
+			for (Iterator<Object> iterator = array.toList().iterator(); iterator.hasNext();) {
+				indentLine(appendable, indent + 4);
+				appendTomlValue(iterator.next(), appendable, indent);
+				if (iterator.hasNext()) {
+					appendable.append(",");
+					appendable.append(System.lineSeparator());
+				}
+			}
+			appendable.append(System.lineSeparator());
+			append(appendable, indent, "]");
+		}
+	}
 
-  private static void appendTomlValue(Object value, Appendable appendable, int indent) throws IOException {
-    Optional<TomlType> tomlType = typeFor(value);
-    assert tomlType.isPresent();
-    switch (tomlType.get()) {
-      case STRING:
-        append(appendable, 0, "\"" + escape((String) value) + "\"");
-        break;
-      case INTEGER:
-      case FLOAT:
-        append(appendable, 0, value.toString());
-        break;
-      case BOOLEAN:
-        append(appendable, 0, ((Boolean) value) ? "true" : "false");
-        break;
-      case OFFSET_DATE_TIME:
-      case LOCAL_DATE_TIME:
-      case LOCAL_DATE:
-      case LOCAL_TIME:
-        append(appendable, 0, "\"" + value.toString() + "\"");
-        break;
-      case ARRAY:
-        toJson((TomlArray) value, appendable, indent + 2);
-        break;
-      case TABLE:
-        toJson((TomlTable) value, appendable, indent + 2);
-        break;
-    }
-  }
+	private static void appendTomlValue(Object value, Appendable appendable, int indent) throws IOException {
+		Optional<TomlType> tomlType = typeFor(value);
+		assert tomlType.isPresent();
+		switch (tomlType.get()) {
+		case STRING:
+			append(appendable, 0, "\"" + escape((String) value) + "\"");
+			break;
+		case INTEGER:
+		case FLOAT:
+			append(appendable, 0, value.toString());
+			break;
+		case BOOLEAN:
+			append(appendable, 0, ((Boolean) value) ? "true" : "false");
+			break;
+		case OFFSET_DATE_TIME:
+		case LOCAL_DATE_TIME:
+		case LOCAL_DATE:
+		case LOCAL_TIME:
+			append(appendable, 0, "\"" + value.toString() + "\"");
+			break;
+		case ARRAY:
+			toJson((TomlArray) value, appendable, indent + 4);
+			break;
+		case TABLE:
+			toJson((TomlTable) value, appendable, indent + 4);
+			break;
+		}
+	}
 
-  private static void append(Appendable appendable, int indent, String line) throws IOException {
-    indentLine(appendable, indent);
-    appendable.append(line);
-  }
+	private static void append(Appendable appendable, int indent, String line) throws IOException {
+		indentLine(appendable, indent);
+		appendable.append(line);
+	}
 
-  private static void appendLine(Appendable appendable, String line) throws IOException {
-    appendable.append(line);
-    appendable.append(System.lineSeparator());
-  }
+	private static void appendLine(Appendable appendable, String line) throws IOException {
+		appendable.append(line);
+		appendable.append(System.lineSeparator());
+	}
 
-  private static void indentLine(Appendable appendable, int indent) throws IOException {
-    for (int i = 0; i < indent; ++i) {
-      appendable.append(' ');
-    }
-  }
+	private static void indentLine(Appendable appendable, int indent) throws IOException {
+		for (int i = 0; i < indent; ++i) {
+			appendable.append(' ');
+		}
+	}
 
-  private static StringBuilder escape(String text) {
-    StringBuilder out = new StringBuilder(text.length());
-    for (int i = 0; i < text.length(); i++) {
-      char ch = text.charAt(i);
-      if (ch == '\'') {
-        out.append("\\'");
-        continue;
-      }
-      if (ch >= 0x20) {
-        out.append(ch);
-        continue;
-      }
+	private static StringBuilder escape(String text) {
+		StringBuilder out = new StringBuilder(text.length());
+		for (int i = 0; i < text.length(); i++) {
+			char ch = text.charAt(i);
+			if (ch == '\"') {
+				out.append('\\');
+				out.append('\"');
+				continue;
+			}
+			if (ch == '\\') {
+			    out.append('\\');
+			    out.append('\\');
+			    continue;
+			}
+			if (ch >= 0x20) {
+				out.append(ch);
+				continue;
+			}
 
-      switch (ch) {
-        case '\t':
-          out.append("\\t");
-          break;
-        case '\b':
-          out.append("\\b");
-          break;
-        case '\n':
-          out.append("\\n");
-          break;
-        case '\r':
-          out.append("\\r");
-          break;
-        case '\f':
-          out.append("\\f");
-          break;
-        default:
-          out.append("\\u").append(String.format("%04x", text.codePointAt(i)));
-      }
-    }
-    return out;
-  }
+			switch (ch) {
+			case '\t':
+				out.append("\\t");
+				break;
+			case '\b':
+				out.append("\\b");
+				break;
+			case '\n':
+				out.append("\\n");
+				break;
+			case '\r':
+				out.append("\\r");
+				break;
+			case '\f':
+				out.append("\\f");
+				break;
+			default:
+				out.append("\\u").append(String.format("%04x", text.codePointAt(i)));
+			}
+		}
+		return out;
+	}
 }

--- a/src/main/java/org/tomlj/JsonSerializer.java
+++ b/src/main/java/org/tomlj/JsonSerializer.java
@@ -16,12 +16,13 @@ import static java.util.Objects.requireNonNull;
 import static org.tomlj.TomlType.typeFor;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 
 final class JsonSerializer {
-  private JsonSerializer() {}
+	private JsonSerializer() {
+	}
 
 	static void toJson(TomlTable table, Appendable appendable) throws IOException {
 		requireNonNull(table);
@@ -36,10 +37,11 @@ final class JsonSerializer {
 			return;
 		}
 		appendLine(appendable, "{");
-		for (Iterator<String> iterator = table.keySet().iterator(); iterator.hasNext();) {
-			String key = iterator.next();
+		for (Iterator<Map.Entry<String, Object>> iterator = table.entrySet().stream().iterator(); iterator.hasNext();) {
+			Map.Entry<String, Object> entry = iterator.next();
+			String key = entry.getKey();
 			append(appendable, indent + 4, "\"" + escape(key) + "\": ");
-			Object value = table.get(Collections.singletonList(key));
+			Object value = entry.getValue();
 			assert value != null;
 			appendTomlValue(value, appendable, indent);
 			if (iterator.hasNext()) {
@@ -134,18 +136,19 @@ final class JsonSerializer {
 		StringBuilder out = new StringBuilder(text.length());
 		for (int i = 0; i < text.length(); i++) {
 			char ch = text.charAt(i);
-			if (ch == '\"') {
+			if (ch == '"') {
 				out.append("\\\"");
 				continue;
 			}
 			if (ch == '\\') {
-			    out.append("\\\\");
-			    continue;
+				out.append("\\\\");
+				continue;
 			}
 			if (ch >= 0x20) {
 				out.append(ch);
 				continue;
 			}
+
 			switch (ch) {
 			case '\t':
 				out.append("\\t");

--- a/src/main/java/org/tomlj/LocalDateVisitor.java
+++ b/src/main/java/org/tomlj/LocalDateVisitor.java
@@ -22,7 +22,7 @@ import org.antlr.v4.runtime.tree.ErrorNode;
 
 final class LocalDateVisitor extends TomlParserBaseVisitor<LocalDate> {
 
-  private static LocalDate INITIAL = LocalDate.parse("1900-01-01");
+  private static final LocalDate INITIAL = LocalDate.parse("1900-01-01");
   private LocalDate date = INITIAL;
 
   @Override

--- a/src/main/java/org/tomlj/MutableTomlArray.java
+++ b/src/main/java/org/tomlj/MutableTomlArray.java
@@ -178,9 +178,10 @@ final class MutableTomlArray implements TomlArray {
 			throw new IllegalArgumentException("Unsupported type " + value.getClass().getSimpleName());
 		}
 		if (type != null) {
-//			if (valueType.get() != type) {
-//				throw new TomlInvalidTypeException("Cannot add a " + TomlType.typeNameFor(value) + " to an array containing " + type.typeName() + "s");
-//			}
+//			 if (valueType.get() != type) {
+//			 throw new TomlInvalidTypeException(
+//			 "Cannot add a " + TomlType.typeNameFor(value) + " to an array containing " + type.typeName() + "s");
+//			 }
 		} else {
 			type = valueType.get();
 		}

--- a/src/main/java/org/tomlj/MutableTomlArray.java
+++ b/src/main/java/org/tomlj/MutableTomlArray.java
@@ -21,134 +21,181 @@ import java.util.stream.Collectors;
 
 final class MutableTomlArray implements TomlArray {
 
-  private static class Element {
-    final Object value;
-    final TomlPosition position;
+	private static class Element {
+		final Object value;
+		final TomlPosition position;
 
-    private Element(Object value, TomlPosition position) {
-      this.value = value;
-      this.position = position;
-    }
-  }
+		private Element(Object value, TomlPosition position) {
+			this.value = value;
+			this.position = position;
+		}
+	}
 
-  static final TomlArray EMPTY = new MutableTomlArray(true);
-  private final List<Element> elements = new ArrayList<>();
-  private final boolean definedAsLiteral;
-  private TomlType type = null;
+	static final TomlArray EMPTY = new MutableTomlArray(true);
+	private final List<Element> elements = new ArrayList<>();
+	private final boolean definedAsLiteral;
+	private TomlType type = null;
 
-  MutableTomlArray() {
-    this(false);
-  }
+	MutableTomlArray() {
+		this(false);
+	}
 
-  MutableTomlArray(boolean definedAsLiteral) {
-    this.definedAsLiteral = definedAsLiteral;
-  }
+	MutableTomlArray(boolean definedAsLiteral) {
+		this.definedAsLiteral = definedAsLiteral;
+	}
 
-  boolean wasDefinedAsLiteral() {
-    return definedAsLiteral;
-  }
+	boolean wasDefinedAsLiteral() {
+		return definedAsLiteral;
+	}
 
-  @Override
-  public int size() {
-    return elements.size();
-  }
+	@Override
+	public int size() {
+		return elements.size();
+	}
 
-  @Override
-  public boolean isEmpty() {
-    return type == null;
-  }
+	@Override
+	public boolean isEmpty() {
+		return type == null;
+	}
 
-  @Override
-  public boolean containsStrings() {
-    return type == null || type == TomlType.STRING;
-  }
+	@Override
+	public boolean containsStrings() {
+		if(iteratearray().contains("STRING")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsLongs() {
-    return type == null || type == TomlType.INTEGER;
-  }
+	@Override
+	public boolean containsLongs() {
+		if(iteratearray().contains("INTEGER")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsDoubles() {
-    return type == null || type == TomlType.FLOAT;
-  }
+	@Override
+	public boolean containsDoubles() {
+		if(iteratearray().contains("FLOAT")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsBooleans() {
-    return type == null || type == TomlType.BOOLEAN;
-  }
+	@Override
+	public boolean containsBooleans() {
+		if(iteratearray().contains("BOOLEAN")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsOffsetDateTimes() {
-    return type == null || type == TomlType.OFFSET_DATE_TIME;
-  }
+	@Override
+	public boolean containsOffsetDateTimes() {
+		if(iteratearray().contains("OFFSET DATE-TIME")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsLocalDateTimes() {
-    return type == null || type == TomlType.LOCAL_DATE_TIME;
-  }
+	@Override
+	public boolean containsLocalDateTimes() {
+		if(iteratearray().contains("LOCAL DATE-TIME")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsLocalDates() {
-    return type == null || type == TomlType.LOCAL_DATE;
-  }
+	@Override
+	public boolean containsLocalDates() {
+		if(iteratearray().contains("LOCAL DATE")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsLocalTimes() {
-    return type == null || type == TomlType.LOCAL_TIME;
-  }
+	@Override
+	public boolean containsLocalTimes() {
+		if(iteratearray().contains("LOCAL TIME")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsArrays() {
-    return type == null || type == TomlType.ARRAY;
-  }
+	@Override
+	public boolean containsArrays() {
+		if(iteratearray().contains("ARRAY")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public boolean containsTables() {
-    return type == null || type == TomlType.TABLE;
-  }
+	@Override
+	public boolean containsTables() {
+		if(iteratearray().contains("TABLE")) {
+			return true;
+		}else {
+			return false;
+		}
+	}
 
-  @Override
-  public Object get(int index) {
-    return elements.get(index).value;
-  }
+	public String iteratearray() {
+		String TypeofElment = "";
+		for (int index = 0; index < elements.size(); index++) {
+			TypeofElment = TypeofElment + "[" + (TomlType.typeNameFor(elements.get(index).value).toUpperCase()) + "]";
+		}
+		return TypeofElment;
+	}
+	
+	@Override
+	public Object get(int index) {
+		return elements.get(index).value;
+	}
 
-  @Override
-  public TomlPosition inputPositionOf(int index) {
-    return elements.get(index).position;
-  }
+	@Override
+	public TomlPosition inputPositionOf(int index) {
+		return elements.get(index).position;
+	}
 
-  MutableTomlArray append(Object value, TomlPosition position) {
-    requireNonNull(value);
-    if (value instanceof Integer) {
-      value = ((Integer) value).longValue();
-    }
+	MutableTomlArray append(Object value, TomlPosition position) {
+		requireNonNull(value);
+		if (value instanceof Integer) {
+			value = ((Integer) value).longValue();
+		}
 
-    TomlType origType = type;
-    Optional<TomlType> valueType = TomlType.typeFor(value);
-    if (!valueType.isPresent()) {
-      throw new IllegalArgumentException("Unsupported type " + value.getClass().getSimpleName());
-    }
-    if (type != null) {
-      if (valueType.get() != type) {
-        throw new TomlInvalidTypeException(
-            "Cannot add a " + TomlType.typeNameFor(value) + " to an array containing " + type.typeName() + "s");
-      }
-    } else {
-      type = valueType.get();
-    }
+		TomlType origType = type;
+		Optional<TomlType> valueType = TomlType.typeFor(value);
+		if (!valueType.isPresent()) {
+			throw new IllegalArgumentException("Unsupported type " + value.getClass().getSimpleName());
+		}
+		if (type != null) {
+//			if (valueType.get() != type) {
+//				throw new TomlInvalidTypeException("Cannot add a " + TomlType.typeNameFor(value) + " to an array containing " + type.typeName() + "s");
+//			}
+		} else {
+			type = valueType.get();
+		}
 
-    try {
-      elements.add(new Element(value, position));
-    } catch (Throwable e) {
-      type = origType;
-      throw e;
-    }
-    return this;
-  }
+		try {
+			elements.add(new Element(value, position));
+		} catch (Throwable e) {
+			type = origType;
+			throw e;
+		}
+		return this;
+	}
 
-  @Override
-  public List<Object> toList() {
-    return elements.stream().map(e -> e.value).collect(Collectors.toList());
-  }
+	@Override
+	public List<Object> toList() {
+		return elements.stream().map(e -> e.value).collect(Collectors.toList());
+	}
 }

--- a/src/main/java/org/tomlj/MutableTomlTable.java
+++ b/src/main/java/org/tomlj/MutableTomlTable.java
@@ -15,9 +15,11 @@ package org.tomlj;
 import static org.tomlj.Parser.parseDottedKey;
 import static org.tomlj.TomlType.typeFor;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -28,208 +30,243 @@ import javax.annotation.Nullable;
 
 final class MutableTomlTable implements TomlTable {
 
-  private static class Element {
-    final Object value;
-    final TomlPosition position;
+	private static class Element {
+		final Object value;
+		final TomlPosition position;
 
-    private Element(Object value, TomlPosition position) {
-      this.value = value;
-      this.position = position;
-    }
-  }
+		private Element(Object value, TomlPosition position) {
+			this.value = value;
+			this.position = position;
+		}
+	}
 
-  static final TomlTable EMPTY = new MutableTomlTable(true);
-  private Map<String, Element> properties = new LinkedHashMap<>();
-  private boolean implicitlyDefined;
+	static final TomlTable EMPTY = new MutableTomlTable(true);
+	private final Map<String, Element> properties = new LinkedHashMap<>();
+	private boolean implicitlyDefined;
 
-  MutableTomlTable() {
-    this(false);
-  }
+	MutableTomlTable() {
+		this(false);
+	}
 
-  private MutableTomlTable(boolean implicitlyDefined) {
-    this.implicitlyDefined = implicitlyDefined;
-  }
+	private MutableTomlTable(boolean implicitlyDefined) {
+		this.implicitlyDefined = implicitlyDefined;
+	}
 
-  @Override
-  public int size() {
-    return properties.size();
-  }
+	@Override
+	public int size() {
+		return properties.size();
+	}
 
-  @Override
-  public boolean isEmpty() {
-    return properties.isEmpty();
-  }
+	@Override
+	public boolean isEmpty() {
+		return properties.isEmpty();
+	}
 
-  @Override
-  public Set<String> keySet() {
-    return properties.keySet();
-  }
+	@Override
+	public Set<String> keySet() {
+		return properties.keySet();
+	}
 
-  @Override
-  public Set<List<String>> keyPathSet(boolean includeTables) {
-    return properties.entrySet().stream().flatMap(entry -> {
-      String key = entry.getKey();
-      List<String> basePath = Collections.singletonList(key);
+	@Override
+	public Set<List<String>> keyPathSet(boolean includeTables) {
+		return properties.entrySet().stream().flatMap(entry -> {
+			String key = entry.getKey();
+			List<String> basePath = Collections.singletonList(key);
 
-      Element element = entry.getValue();
-      if (!(element.value instanceof TomlTable)) {
-        return Stream.of(basePath);
-      }
+			Element element = entry.getValue();
+			if (!(element.value instanceof TomlTable)) {
+				return Stream.of(basePath);
+			}
 
-      Stream<List<String>> subKeys = ((TomlTable) element.value).keyPathSet(includeTables).stream().map(subPath -> {
-        List<String> path = new ArrayList<>(subPath.size() + 1);
-        path.add(key);
-        path.addAll(subPath);
-        return path;
-      });
+			Stream<List<String>> subKeys = ((TomlTable) element.value).keyPathSet(includeTables).stream()
+					.map(subPath -> {
+						List<String> path = new ArrayList<>(subPath.size() + 1);
+						path.add(key);
+						path.addAll(subPath);
+						return path;
+					});
 
-      if (includeTables) {
-        return Stream.concat(Stream.of(basePath), subKeys);
-      } else {
-        return subKeys;
-      }
-    }).collect(Collectors.toSet());
-  }
+			if (includeTables) {
+				return Stream.concat(Stream.of(basePath), subKeys);
+			} else {
+				return subKeys;
+			}
+		}).collect(Collectors.toSet());
+	}
 
-  @Override
-  @Nullable
-  @SuppressWarnings("unchecked")
-  public Object get(List<String> path) {
-    if (path.isEmpty()) {
-      return this;
-    }
-    Element element = getElement(path);
-    return (element != null) ? element.value : null;
-  }
+	@Override
+	public Set<Entry<String, Object>> entrySet() {
+		return properties.entrySet().stream()
+				.map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().value))
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+	}
 
-  @Override
-  @Nullable
-  public TomlPosition inputPositionOf(List<String> path) {
-    if (path.isEmpty()) {
-      return TomlPosition.positionAt(1, 1);
-    }
-    Element element = getElement(path);
-    return (element != null) ? element.position : null;
-  }
+	@Override
+	public Set<Entry<List<String>, Object>> entryPathSet(boolean includeTables) {
+		return properties.entrySet().stream().flatMap(entry -> {
+			String key = entry.getKey();
+			List<String> entryPath = Collections.singletonList(key);
+			Element element = entry.getValue();
 
-  private Element getElement(List<String> path) {
-    MutableTomlTable table = this;
-    int depth = path.size();
-    assert depth > 0;
-    for (int i = 0; i < (depth - 1); ++i) {
-      Element element = table.properties.get(path.get(i));
-      if (element == null) {
-        return null;
-      }
-      if (element.value instanceof MutableTomlTable) {
-        table = (MutableTomlTable) element.value;
-        continue;
-      }
-      return null;
-    }
-    return table.properties.get(path.get(depth - 1));
-  }
+			if (!(element.value instanceof TomlTable)) {
+				return Stream.of(new AbstractMap.SimpleEntry<>(entryPath, element.value));
+			}
 
-  @Override
-  public Map<String, Object> toMap() {
-    return properties.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> e.getValue().value));
-  }
+			Stream<Entry<List<String>, Object>> subEntries = ((TomlTable) element.value).entryPathSet(includeTables)
+					.stream().map(subEntry -> {
+						List<String> subPath = subEntry.getKey();
+						List<String> path = new ArrayList<>(subPath.size() + 1);
+						path.add(key);
+						path.addAll(subPath);
+						return new AbstractMap.SimpleEntry<>(path, subEntry.getValue());
+					});
 
-  MutableTomlTable createTable(List<String> path, TomlPosition position) {
-    if (path.isEmpty()) {
-      return this;
-    }
+			if (includeTables) {
+				return Stream.concat(Stream.of(new AbstractMap.SimpleEntry<>(entryPath, element.value)), subEntries);
+			} else {
+				return subEntries;
+			}
+		}).collect(Collectors.toCollection(LinkedHashSet::new));
+	}
 
-    int depth = path.size();
-    MutableTomlTable table = ensureTable(path.subList(0, depth - 1), position, true);
+	@Override
+	@Nullable
+	public Object get(List<String> path) {
+		if (path.isEmpty()) {
+			return this;
+		}
+		Element element = getElement(path);
+		return (element != null) ? element.value : null;
+	}
 
-    String key = path.get(depth - 1);
-    Element element = table.properties.get(key);
-    if (element == null) {
-      MutableTomlTable newTable = new MutableTomlTable();
-      table.properties.put(key, new Element(newTable, position));
-      return newTable;
-    }
-    if (element.value instanceof MutableTomlTable) {
-      table = (MutableTomlTable) element.value;
-      if (table.implicitlyDefined) {
-        table.implicitlyDefined = false;
-        table.properties.put(key, new Element(table, position));
-        return table;
-      }
-    }
-    String message = Toml.joinKeyPath(path) + " previously defined at " + element.position;
-    throw new TomlParseError(message, position);
-  }
+	@Override
+	@Nullable
+	public TomlPosition inputPositionOf(List<String> path) {
+		if (path.isEmpty()) {
+			return TomlPosition.positionAt(1, 1);
+		}
+		Element element = getElement(path);
+		return (element != null) ? element.position : null;
+	}
 
-  MutableTomlTable createArrayTable(List<String> path, TomlPosition position) {
-    if (path.isEmpty()) {
-      throw new IllegalArgumentException("empty path");
-    }
+	private Element getElement(List<String> path) {
+		MutableTomlTable table = this;
+		int depth = path.size();
+		assert depth > 0;
+		for (int i = 0; i < (depth - 1); ++i) {
+			Element element = table.properties.get(path.get(i));
+			if (element == null) {
+				return null;
+			}
+			if (element.value instanceof MutableTomlTable) {
+				table = (MutableTomlTable) element.value;
+				continue;
+			}
+			return null;
+		}
+		return table.properties.get(path.get(depth - 1));
+	}
 
-    int depth = path.size();
-    MutableTomlTable table = ensureTable(path.subList(0, depth - 1), position, true);
+	@Override
+	public Map<String, Object> toMap() {
+		return properties.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> e.getValue().value));
+	}
 
-    String key = path.get(depth - 1);
-    Element element = table.properties.computeIfAbsent(key, k -> new Element(new MutableTomlArray(), position));
-    if (!(element.value instanceof MutableTomlArray)) {
-      String message = Toml.joinKeyPath(path) + " is not an array (previously defined at " + element.position + ")";
-      throw new TomlParseError(message, position);
-    }
-    MutableTomlArray array = (MutableTomlArray) element.value;
-    if (array.wasDefinedAsLiteral()) {
-      String message = Toml.joinKeyPath(path) + " previously defined as a literal array at " + element.position;
-      throw new TomlParseError(message, position);
-    }
-    MutableTomlTable newTable = new MutableTomlTable();
-    array.append(newTable, position);
-    return newTable;
-  }
+	MutableTomlTable createTable(List<String> path, TomlPosition position) {
+		if (path.isEmpty()) {
+			return this;
+		}
 
-  MutableTomlTable set(String keyPath, Object value, TomlPosition position) {
-    return set(parseDottedKey(keyPath), value, position);
-  }
+		int depth = path.size();
+		MutableTomlTable table = ensureTable(path.subList(0, depth - 1), position, true);
 
-  MutableTomlTable set(List<String> path, Object value, TomlPosition position) {
-    int depth = path.size();
-    assert (depth > 0);
-    assert (value != null);
-    if (value instanceof Integer) {
-      value = ((Integer) value).longValue();
-    }
-    assert (typeFor(value).isPresent()) : "Unexpected value of type " + value.getClass();
+		String key = path.get(depth - 1);
+		Element element = table.properties.get(key);
+		if (element == null) {
+			MutableTomlTable newTable = new MutableTomlTable();
+			table.properties.put(key, new Element(newTable, position));
+			return newTable;
+		}
+		if (element.value instanceof MutableTomlTable) {
+			table = (MutableTomlTable) element.value;
+			if (table.implicitlyDefined) {
+				table.implicitlyDefined = false;
+				table.properties.put(key, new Element(table, position));
+				return table;
+			}
+		}
+		String message = Toml.joinKeyPath(path) + " previously defined at " + element.position;
+		throw new TomlParseError(message, position);
+	}
 
-    MutableTomlTable table = ensureTable(path.subList(0, depth - 1), position, false);
-    Element prevElem = table.properties.putIfAbsent(path.get(depth - 1), new Element(value, position));
-    if (prevElem != null) {
-      String pathString = Toml.joinKeyPath(path);
-      String message = pathString + " previously defined at " + prevElem.position;
-      throw new TomlParseError(message, position);
-    }
-    return this;
-  }
+	MutableTomlTable createArrayTable(List<String> path, TomlPosition position) {
+		if (path.isEmpty()) {
+			throw new IllegalArgumentException("empty path");
+		}
 
-  private MutableTomlTable ensureTable(List<String> path, TomlPosition position, boolean followArrayTables) {
-    MutableTomlTable table = this;
-    int depth = path.size();
-    for (int i = 0; i < depth; ++i) {
-      Element element =
-          table.properties.computeIfAbsent(path.get(i), k -> new Element(new MutableTomlTable(true), position));
-      if (element.value instanceof MutableTomlTable) {
-        table = (MutableTomlTable) element.value;
-        continue;
-      }
-      if (followArrayTables && element.value instanceof MutableTomlArray) {
-        MutableTomlArray array = (MutableTomlArray) element.value;
-        if (!array.wasDefinedAsLiteral() && !array.isEmpty() && array.containsTables()) {
-          table = (MutableTomlTable) array.get(array.size() - 1);
-          continue;
-        }
-      }
-      String message =
-          Toml.joinKeyPath(path.subList(0, i + 1)) + " is not a table (previously defined at " + element.position + ")";
-      throw new TomlParseError(message, position);
-    }
-    return table;
-  }
+		int depth = path.size();
+		MutableTomlTable table = ensureTable(path.subList(0, depth - 1), position, true);
+
+		String key = path.get(depth - 1);
+		Element element = table.properties.computeIfAbsent(key, k -> new Element(new MutableTomlArray(), position));
+		if (!(element.value instanceof MutableTomlArray)) {
+			String message = Toml.joinKeyPath(path) + " is not an array (previously defined at " + element.position
+					+ ")";
+			throw new TomlParseError(message, position);
+		}
+		MutableTomlArray array = (MutableTomlArray) element.value;
+		if (array.wasDefinedAsLiteral()) {
+			String message = Toml.joinKeyPath(path) + " previously defined as a literal array at " + element.position;
+			throw new TomlParseError(message, position);
+		}
+		MutableTomlTable newTable = new MutableTomlTable();
+		array.append(newTable, position);
+		return newTable;
+	}
+
+	MutableTomlTable set(String keyPath, Object value, TomlPosition position) {
+		return set(parseDottedKey(keyPath), value, position);
+	}
+
+	MutableTomlTable set(List<String> path, Object value, TomlPosition position) {
+		int depth = path.size();
+		assert (depth > 0);
+		if (value instanceof Integer) {
+			value = ((Integer) value).longValue();
+		}
+		assert (typeFor(value).isPresent()) : "Unexpected value of type " + value.getClass();
+
+		MutableTomlTable table = ensureTable(path.subList(0, depth - 1), position, false);
+		Element prevElem = table.properties.putIfAbsent(path.get(depth - 1), new Element(value, position));
+		if (prevElem != null) {
+			String pathString = Toml.joinKeyPath(path);
+			String message = pathString + " previously defined at " + prevElem.position;
+			throw new TomlParseError(message, position);
+		}
+		return this;
+	}
+
+	private MutableTomlTable ensureTable(List<String> path, TomlPosition position, boolean followArrayTables) {
+		MutableTomlTable table = this;
+		int depth = path.size();
+		for (int i = 0; i < depth; ++i) {
+			Element element = table.properties.computeIfAbsent(path.get(i),
+					k -> new Element(new MutableTomlTable(true), position));
+			if (element.value instanceof MutableTomlTable) {
+				table = (MutableTomlTable) element.value;
+				continue;
+			}
+			if (followArrayTables && element.value instanceof MutableTomlArray) {
+				MutableTomlArray array = (MutableTomlArray) element.value;
+				if (!array.wasDefinedAsLiteral() && !array.isEmpty() && array.containsTables()) {
+					table = (MutableTomlTable) array.get(array.size() - 1);
+					continue;
+				}
+			}
+			String message = Toml.joinKeyPath(path.subList(0, i + 1)) + " is not a table (previously defined at "
+					+ element.position + ")";
+			throw new TomlParseError(message, position);
+		}
+		return table;
+	}
 }

--- a/src/main/java/org/tomlj/MutableTomlTable.java
+++ b/src/main/java/org/tomlj/MutableTomlTable.java
@@ -17,7 +17,7 @@ import static org.tomlj.TomlType.typeFor;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -39,7 +39,7 @@ final class MutableTomlTable implements TomlTable {
   }
 
   static final TomlTable EMPTY = new MutableTomlTable(true);
-  private Map<String, Element> properties = new HashMap<>();
+  private Map<String, Element> properties = new LinkedHashMap<>();
   private boolean implicitlyDefined;
 
   MutableTomlTable() {

--- a/src/main/java/org/tomlj/Parser.java
+++ b/src/main/java/org/tomlj/Parser.java
@@ -26,7 +26,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 final class Parser {
-	private Parser() {}
+    private Parser() {}
 
 	static TomlParseResult parse(CharStream stream, TomlVersion version, boolean throwiferror) {
 		TomlLexer lexer = new TomlLexer(stream);
@@ -111,7 +111,8 @@ final class Parser {
 		String[] sSplitKey = Key.split("\\.");
 		String sWrappedKey = "";
 		for (String str : sSplitKey) {
-			if (str.contains(" ")) {
+			str = str.trim();
+			if (str.contains(" ") && !str.contains("\"") && !str.contains("'")) {
 				str = "\"" + str + "\"";
 			}
 			sWrappedKey = sWrappedKey + str + ".";

--- a/src/main/java/org/tomlj/Parser.java
+++ b/src/main/java/org/tomlj/Parser.java
@@ -26,7 +26,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 final class Parser {
-    private Parser() {}
+	private Parser() {
+	}
 
 	static TomlParseResult parse(CharStream stream, TomlVersion version, boolean throwiferror) {
 		TomlLexer lexer = new TomlLexer(stream);
@@ -67,6 +68,16 @@ final class Parser {
 			}
 
 			@Override
+			public Set<Map.Entry<String, Object>> entrySet() {
+				return table.entrySet();
+			}
+
+			@Override
+			public Set<Map.Entry<List<String>, Object>> entryPathSet(boolean includeTables) {
+				return table.entryPathSet(includeTables);
+			}
+
+			@Override
 			@Nullable
 			public Object get(List<String> path) {
 				return table.get(path);
@@ -91,9 +102,8 @@ final class Parser {
 	}
 
 	static List<String> parseDottedKey(String dottedKey) {
-		dottedKey = wrapKey(dottedKey);
 		TomlLexer lexer = new TomlLexer(CharStreams.fromString(dottedKey));
-		lexer.mode(TomlLexer.KeyMode);
+		lexer.mode(TomlLexer.TomlKeyMode);
 		TomlParser parser = new TomlParser(new CommonTokenStream(lexer));
 		parser.removeErrorListeners();
 		AccumulatingErrorListener errorListener = new AccumulatingErrorListener();
@@ -105,19 +115,5 @@ final class Parser {
 			throw new IllegalArgumentException("Invalid key: " + e.getMessage(), e);
 		}
 		return keyList;
-	}
-
-	private static String wrapKey(String Key) {
-		String[] sSplitKey = Key.split("\\.");
-		String sWrappedKey = "";
-		for (String str : sSplitKey) {
-			str = str.trim();
-			if (str.contains(" ") && !str.contains("\"") && !str.contains("'")) {
-				str = "\"" + str + "\"";
-			}
-			sWrappedKey = sWrappedKey + str + ".";
-		}
-		sWrappedKey = sWrappedKey.replaceAll("\\.$", "");
-		return sWrappedKey;
 	}
 }

--- a/src/main/java/org/tomlj/Toml.java
+++ b/src/main/java/org/tomlj/Toml.java
@@ -38,12 +38,22 @@ public final class Toml {
    * Parse a TOML string.
    *
    * @param input The input to parse.
-   * @return The parse result.
+   * @return The parse result. Continues parse even if error.
    */
   public static TomlParseResult parse(String input) {
-    return parse(input, TomlVersion.LATEST);
+    return parse(input, TomlVersion.LATEST, false);
   }
 
+  /**
+   * Parse a TOML string.
+   *
+   * @param input The input to parse.
+   * @return The parse result. Continues parse even if error.
+   */
+  public static TomlParseResult parse(String input, boolean throwiferror) {
+    return parse(input, TomlVersion.LATEST, throwiferror);
+  }
+  
   /**
    * Parse a TOML string.
    *
@@ -51,9 +61,9 @@ public final class Toml {
    * @param version The version level to parse at.
    * @return The parse result.
    */
-  public static TomlParseResult parse(String input, TomlVersion version) {
+  public static TomlParseResult parse(String input, TomlVersion version, boolean throwiferror) {
     CharStream stream = CharStreams.fromString(input);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, version.canonical, throwiferror);
   }
 
   /**
@@ -61,12 +71,24 @@ public final class Toml {
    *
    * @param file The input file to parse.
    * @return The parse result.
-   * @throws IOException If an IO error occurs.
+   * @throws IOException If an IO error occurs. Continues parse even if error.
    */
   public static TomlParseResult parse(Path file) throws IOException {
-    return parse(file, TomlVersion.LATEST);
+    return parse(file, TomlVersion.LATEST, false);
   }
 
+  /**
+   * Parse a TOML file.
+   *
+   * @param file The input file to parse.
+   * @return The parse result.
+   * @throws IOException If an IO error occurs. Continues parse even if error.
+   */
+  public static TomlParseResult parse(Path file, boolean throwiferror) throws IOException {
+    return parse(file, TomlVersion.LATEST, throwiferror);
+  }
+
+  
   /**
    * Parse a TOML file.
    *
@@ -75,9 +97,9 @@ public final class Toml {
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(Path file, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(Path file, TomlVersion version, boolean throwiferror) throws IOException {
     CharStream stream = CharStreams.fromPath(file);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, version.canonical, throwiferror);
   }
 
   /**
@@ -85,10 +107,21 @@ public final class Toml {
    *
    * @param is The input stream to read the TOML document from.
    * @return The parse result.
-   * @throws IOException If an IO error occurs.
+   * @throws IOException If an IO error occurs. Continues parse even if error.
    */
   public static TomlParseResult parse(InputStream is) throws IOException {
-    return parse(is, TomlVersion.LATEST);
+    return parse(is, TomlVersion.LATEST, false);
+  }
+  
+  /**
+   * Parse a TOML input stream.
+   *
+   * @param is The input stream to read the TOML document from.
+   * @return The parse result.
+   * @throws IOException If an IO error occurs.
+   */
+  public static TomlParseResult parse(InputStream is, boolean throwiferror) throws IOException {
+    return parse(is, TomlVersion.LATEST, throwiferror);
   }
 
   /**
@@ -99,9 +132,9 @@ public final class Toml {
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(InputStream is, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(InputStream is, TomlVersion version, boolean throwiferror) throws IOException {
     CharStream stream = CharStreams.fromStream(is);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, version.canonical, throwiferror);
   }
 
   /**
@@ -109,10 +142,21 @@ public final class Toml {
    *
    * @param reader The reader to obtain the TOML document from.
    * @return The parse result.
-   * @throws IOException If an IO error occurs.
+   * @throws IOException If an IO error occurs. Continues parse even if error.
    */
   public static TomlParseResult parse(Reader reader) throws IOException {
-    return parse(reader, TomlVersion.LATEST);
+    return parse(reader, TomlVersion.LATEST, false);
+  }
+  
+  /**
+   * Parse a TOML reader.
+   *
+   * @param reader The reader to obtain the TOML document from.
+   * @return The parse result.
+   * @throws IOException If an IO error occurs.
+   */
+  public static TomlParseResult parse(Reader reader, boolean throwiferror) throws IOException {
+    return parse(reader, TomlVersion.LATEST, throwiferror);
   }
 
   /**
@@ -123,9 +167,20 @@ public final class Toml {
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(Reader reader, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(Reader reader, TomlVersion version, boolean throwiferror) throws IOException {
     CharStream stream = CharStreams.fromReader(reader);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, version.canonical, throwiferror);
+  }
+
+  /**
+   * Parse a TOML reader.
+   *
+   * @param channel The channel to read the TOML document from.
+   * @return The parse result.
+   * @throws IOException If an IO error occurs. Continues parse even if error.
+   */
+  public static TomlParseResult parse(ReadableByteChannel channel) throws IOException {
+    return parse(channel, TomlVersion.LATEST, false);
   }
 
   /**
@@ -135,10 +190,10 @@ public final class Toml {
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(ReadableByteChannel channel) throws IOException {
-    return parse(channel, TomlVersion.LATEST);
+  public static TomlParseResult parse(ReadableByteChannel channel, boolean throwiferror) throws IOException {
+    return parse(channel, TomlVersion.LATEST, throwiferror);
   }
-
+  
   /**
    * Parse a TOML input stream.
    *
@@ -147,9 +202,9 @@ public final class Toml {
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(ReadableByteChannel channel, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(ReadableByteChannel channel, TomlVersion version, boolean throwiferror) throws IOException {
     CharStream stream = CharStreams.fromChannel(channel);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, version.canonical, throwiferror);
   }
 
   /**

--- a/src/main/java/org/tomlj/Toml.java
+++ b/src/main/java/org/tomlj/Toml.java
@@ -30,272 +30,345 @@ import org.antlr.v4.runtime.CharStreams;
  * Methods for parsing data stored in Tom's Obvious, Minimal Language (TOML).
  */
 public final class Toml {
-  private static final Pattern simpleKeyPattern = Pattern.compile("^[A-Za-z0-9_-]+$");
+	private static final Pattern simpleKeyPattern = Pattern.compile("^[A-Za-z0-9_-]+$");
 
-  private Toml() {}
+	private Toml() {}
 
-  /**
-   * Parse a TOML string.
-   *
-   * @param input The input to parse.
-   * @return The parse result. Continues parse even if error.
-   */
-  public static TomlParseResult parse(String input) {
-    return parse(input, TomlVersion.LATEST, false);
-  }
+	/**
+	 * Parse a TOML string.
+	 *
+	 * @param input The input to parse.
+	 * @return The parse result. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(String input) {
+		return parse(input, TomlVersion.LATEST, false);
+	}
 
-  /**
-   * Parse a TOML string.
-   *
-   * @param input The input to parse.
-   * @return The parse result. Continues parse even if error.
-   */
-  public static TomlParseResult parse(String input, boolean throwiferror) {
-    return parse(input, TomlVersion.LATEST, throwiferror);
-  }
-  
-  /**
-   * Parse a TOML string.
-   *
-   * @param input The input to parse.
-   * @param version The version level to parse at.
-   * @return The parse result.
-   */
-  public static TomlParseResult parse(String input, TomlVersion version, boolean throwiferror) {
-    CharStream stream = CharStreams.fromString(input);
-    return Parser.parse(stream, version.canonical, throwiferror);
-  }
+	/**
+	 * Parse a TOML string.
+	 *
+	 * @param input  The input to parse.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(String input, boolean throwiferror) {
+		return parse(input, TomlVersion.LATEST, throwiferror);
+	}
 
-  /**
-   * Parse a TOML file.
-   *
-   * @param file The input file to parse.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs. Continues parse even if error.
-   */
-  public static TomlParseResult parse(Path file) throws IOException {
-    return parse(file, TomlVersion.LATEST, false);
-  }
+	/**
+	 * Parse a TOML string.
+	 *
+	 * @param input The input to parse.
+	 * @param version The version level to parse at.
+	 * @return The parse result. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(String input, TomlVersion version) {
+		CharStream stream = CharStreams.fromString(input);
+		return Parser.parse(stream, version.canonical, false);
+	}
 
-  /**
-   * Parse a TOML file.
-   *
-   * @param file The input file to parse.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs. Continues parse even if error.
-   */
-  public static TomlParseResult parse(Path file, boolean throwiferror) throws IOException {
-    return parse(file, TomlVersion.LATEST, throwiferror);
-  }
+	/**
+	 * Parse a TOML string.
+	 *
+	 * @param input The input to parse.
+	 * @param version The version level to parse at.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 */
+	public static TomlParseResult parse(String input, TomlVersion version, boolean throwiferror) {
+		CharStream stream = CharStreams.fromString(input);
+		return Parser.parse(stream, version.canonical, throwiferror);
+	}
 
-  
-  /**
-   * Parse a TOML file.
-   *
-   * @param file The input file to parse.
-   * @param version The version level to parse at.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs.
-   */
-  public static TomlParseResult parse(Path file, TomlVersion version, boolean throwiferror) throws IOException {
-    CharStream stream = CharStreams.fromPath(file);
-    return Parser.parse(stream, version.canonical, throwiferror);
-  }
+	/**
+	 * Parse a TOML file.
+	 *
+	 * @param file The input file to parse.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(Path file) throws IOException {
+		return parse(file, TomlVersion.LATEST, false);
+	}
 
-  /**
-   * Parse a TOML input stream.
-   *
-   * @param is The input stream to read the TOML document from.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs. Continues parse even if error.
-   */
-  public static TomlParseResult parse(InputStream is) throws IOException {
-    return parse(is, TomlVersion.LATEST, false);
-  }
-  
-  /**
-   * Parse a TOML input stream.
-   *
-   * @param is The input stream to read the TOML document from.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs.
-   */
-  public static TomlParseResult parse(InputStream is, boolean throwiferror) throws IOException {
-    return parse(is, TomlVersion.LATEST, throwiferror);
-  }
+	/**
+	 * Parse a TOML file.
+	 *
+	 * @param file The input file to parse.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(Path file, boolean throwiferror) throws IOException {
+		return parse(file, TomlVersion.LATEST, throwiferror);
+	}
 
-  /**
-   * Parse a TOML input stream.
-   *
-   * @param is The input stream to read the TOML document from.
-   * @param version The version level to parse at.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs.
-   */
-  public static TomlParseResult parse(InputStream is, TomlVersion version, boolean throwiferror) throws IOException {
-    CharStream stream = CharStreams.fromStream(is);
-    return Parser.parse(stream, version.canonical, throwiferror);
-  }
+	/**
+	 * Parse a TOML file.
+	 *
+	 * @param file The input file to parse.
+	 * @param version The version level to parse at.
+	 * @return The parse result.
+	 * @throws IOExceptio If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(Path file, TomlVersion version) throws IOException {
+		CharStream stream = CharStreams.fromPath(file);
+		return Parser.parse(stream, version.canonical, false);
+	}
 
-  /**
-   * Parse a TOML reader.
-   *
-   * @param reader The reader to obtain the TOML document from.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs. Continues parse even if error.
-   */
-  public static TomlParseResult parse(Reader reader) throws IOException {
-    return parse(reader, TomlVersion.LATEST, false);
-  }
-  
-  /**
-   * Parse a TOML reader.
-   *
-   * @param reader The reader to obtain the TOML document from.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs.
-   */
-  public static TomlParseResult parse(Reader reader, boolean throwiferror) throws IOException {
-    return parse(reader, TomlVersion.LATEST, throwiferror);
-  }
+	/**
+	 * Parse a TOML file.
+	 *
+	 * @param file The input file to parse.
+	 * @param version The version level to parse at.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public static TomlParseResult parse(Path file, TomlVersion version, boolean throwiferror) throws IOException {
+		CharStream stream = CharStreams.fromPath(file);
+		return Parser.parse(stream, version.canonical, throwiferror);
+	}
 
-  /**
-   * Parse a TOML input stream.
-   *
-   * @param reader The reader to obtain the TOML document from.
-   * @param version The version level to parse at.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs.
-   */
-  public static TomlParseResult parse(Reader reader, TomlVersion version, boolean throwiferror) throws IOException {
-    CharStream stream = CharStreams.fromReader(reader);
-    return Parser.parse(stream, version.canonical, throwiferror);
-  }
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param is The input stream to read the TOML document from.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(InputStream is) throws IOException {
+		return parse(is, TomlVersion.LATEST, false);
+	}
 
-  /**
-   * Parse a TOML reader.
-   *
-   * @param channel The channel to read the TOML document from.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs. Continues parse even if error.
-   */
-  public static TomlParseResult parse(ReadableByteChannel channel) throws IOException {
-    return parse(channel, TomlVersion.LATEST, false);
-  }
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param is The input stream to read the TOML document from.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public static TomlParseResult parse(InputStream is, boolean throwiferror) throws IOException {
+		return parse(is, TomlVersion.LATEST, throwiferror);
+	}
 
-  /**
-   * Parse a TOML reader.
-   *
-   * @param channel The channel to read the TOML document from.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs.
-   */
-  public static TomlParseResult parse(ReadableByteChannel channel, boolean throwiferror) throws IOException {
-    return parse(channel, TomlVersion.LATEST, throwiferror);
-  }
-  
-  /**
-   * Parse a TOML input stream.
-   *
-   * @param channel The channel to read the TOML document from.
-   * @param version The version level to parse at.
-   * @return The parse result.
-   * @throws IOException If an IO error occurs.
-   */
-  public static TomlParseResult parse(ReadableByteChannel channel, TomlVersion version, boolean throwiferror) throws IOException {
-    CharStream stream = CharStreams.fromChannel(channel);
-    return Parser.parse(stream, version.canonical, throwiferror);
-  }
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param is The input stream to read the TOML document from.
+	 * @param version The version level to parse at.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(InputStream is, TomlVersion version) throws IOException {
+		CharStream stream = CharStreams.fromStream(is);
+		return Parser.parse(stream, version.canonical, false);
+	}
 
-  /**
-   * Parse a dotted key into individual parts.
-   *
-   * @param dottedKey A dotted key (e.g. {@code server.address.port}).
-   * @return A list of individual keys in the path.
-   * @throws IllegalArgumentException If the dotted key cannot be parsed.
-   */
-  public static List<String> parseDottedKey(String dottedKey) {
-    requireNonNull(dottedKey);
-    return Parser.parseDottedKey(dottedKey);
-  }
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param is The input stream to read the TOML document from.
+	 * @param version The version level to parse at.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public static TomlParseResult parse(InputStream is, TomlVersion version, boolean throwiferror) throws IOException {
+		CharStream stream = CharStreams.fromStream(is);
+		return Parser.parse(stream, version.canonical, throwiferror);
+	}
 
-  /**
-   * Join a list of keys into a single dotted key string.
-   *
-   * @param path The list of keys that form the path.
-   * @return The path string.
-   */
-  public static String joinKeyPath(List<String> path) {
-    requireNonNull(path);
+	/**
+	 * Parse a TOML reader.
+	 *
+	 * @param reader The reader to obtain the TOML document from.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(Reader reader) throws IOException {
+		return parse(reader, TomlVersion.LATEST, false);
+	}
 
-    StringJoiner joiner = new StringJoiner(".");
-    for (String key : path) {
-      if (simpleKeyPattern.matcher(key).matches()) {
-        joiner.add(key);
-      } else {
-        joiner.add("\"" + tomlEscape(key) + '\"');
-      }
-    }
-    return joiner.toString();
-  }
+	/**
+	 * Parse a TOML reader.
+	 *
+	 * @param reader The reader to obtain the TOML document from.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public static TomlParseResult parse(Reader reader, boolean throwiferror) throws IOException {
+		return parse(reader, TomlVersion.LATEST, throwiferror);
+	}
 
-  /**
-   * Get the canonical form of the dotted key.
-   *
-   * @param dottedKey A dotted key (e.g. {@code server.address.port}).
-   * @return The canonical form of the dotted key.
-   * @throws IllegalArgumentException If the dotted key cannot be parsed.
-   */
-  public static String canonicalDottedKey(String dottedKey) {
-    return joinKeyPath(parseDottedKey(dottedKey));
-  }
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param reader The reader to obtain the TOML document from.
+	 * @param version The version level to parse at.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(Reader reader, TomlVersion version) throws IOException {
+		CharStream stream = CharStreams.fromReader(reader);
+		return Parser.parse(stream, version.canonical, false);
+	}
 
-  /**
-   * Escape a text string using the TOML escape sequences.
-   *
-   * @param text The text string to escape.
-   * @return A {@link StringBuilder} holding the results of escaping the text.
-   */
-  public static StringBuilder tomlEscape(String text) {
-    final StringBuilder out = new StringBuilder();
-    for (int i = 0; i < text.length(); i++) {
-      int codepoint = text.codePointAt(i);
-      if (Character.charCount(codepoint) > 1) {
-        out.append("\\U").append(String.format("%08x", codepoint));
-        ++i;
-        continue;
-      }
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param reader The reader to obtain the TOML document from.
+	 * @param version The version level to parse at.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public static TomlParseResult parse(Reader reader, TomlVersion version, boolean throwiferror) throws IOException {
+		CharStream stream = CharStreams.fromReader(reader);
+		return Parser.parse(stream, version.canonical, throwiferror);
+	}
 
-      char ch = Character.toChars(codepoint)[0];
-      if (ch == '\'') {
-        out.append("\\'");
-        continue;
-      }
-      if (ch >= 0x20 && ch < 0x7F) {
-        out.append(ch);
-        continue;
-      }
+	/**
+	 * Parse a TOML reader.
+	 *
+	 * @param channel The channel to read the TOML document from.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(ReadableByteChannel channel) throws IOException {
+		return parse(channel, TomlVersion.LATEST, false);
+	}
 
-      switch (ch) {
-        case '\t':
-          out.append("\\t");
-          break;
-        case '\b':
-          out.append("\\b");
-          break;
-        case '\n':
-          out.append("\\n");
-          break;
-        case '\r':
-          out.append("\\r");
-          break;
-        case '\f':
-          out.append("\\f");
-          break;
-        default:
-          out.append("\\u").append(String.format("%04x", codepoint));
-      }
-    }
-    return out;
-  }
+	/**
+	 * Parse a TOML reader.
+	 *
+	 * @param channel The channel to read the TOML document from.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public static TomlParseResult parse(ReadableByteChannel channel, boolean throwiferror) throws IOException {
+		return parse(channel, TomlVersion.LATEST, throwiferror);
+	}
+
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param channel The channel to read the TOML document from.
+	 * @param version The version level to parse at.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs. Continues parse even if error.
+	 */
+	public static TomlParseResult parse(ReadableByteChannel channel, TomlVersion version) throws IOException {
+		CharStream stream = CharStreams.fromChannel(channel);
+		return Parser.parse(stream, version.canonical, false);
+	}
+
+	/**
+	 * Parse a TOML input stream.
+	 *
+	 * @param channel The channel to read the TOML document from.
+	 * @param version The version level to parse at.
+	 * @param throwiferror To throw error immediately while parsing.
+	 * @return The parse result.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public static TomlParseResult parse(ReadableByteChannel channel, TomlVersion version, boolean throwiferror)	throws IOException {
+		CharStream stream = CharStreams.fromChannel(channel);
+		return Parser.parse(stream, version.canonical, throwiferror);
+	}
+
+	/**
+	 * Parse a dotted key into individual parts.
+	 *
+	 * @param dottedKey A dotted key (e.g. {@code server.address.port}).
+	 * @return A list of individual keys in the path.
+	 * @throws IllegalArgumentException If the dotted key cannot be parsed.
+	 */
+	public static List<String> parseDottedKey(String dottedKey) {
+		requireNonNull(dottedKey);
+		return Parser.parseDottedKey(dottedKey);
+	}
+
+	/**
+	 * Join a list of keys into a single dotted key string.
+	 *
+	 * @param path The list of keys that form the path.
+	 * @return The path string.
+	 */
+	public static String joinKeyPath(List<String> path) {
+		requireNonNull(path);
+
+		StringJoiner joiner = new StringJoiner(".");
+		for (String key : path) {
+			if (simpleKeyPattern.matcher(key).matches()) {
+				joiner.add(key);
+			} else {
+				joiner.add("\"" + tomlEscape(key) + '\"');
+			}
+		}
+		return joiner.toString();
+	}
+
+	/**
+	 * Get the canonical form of the dotted key.
+	 *
+	 * @param dottedKey A dotted key (e.g. {@code server.address.port}).
+	 * @return The canonical form of the dotted key.
+	 * @throws IllegalArgumentException If the dotted key cannot be parsed.
+	 */
+	public static String canonicalDottedKey(String dottedKey) {
+		return joinKeyPath(parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Escape a text string using the TOML escape sequences.
+	 *
+	 * @param text The text string to escape.
+	 * @return A {@link StringBuilder} holding the results of escaping the text.
+	 */
+	public static StringBuilder tomlEscape(String text) {
+		final StringBuilder out = new StringBuilder();
+		for (int i = 0; i < text.length(); i++) {
+			int codepoint = text.codePointAt(i);
+			if (Character.charCount(codepoint) > 1) {
+				out.append("\\U").append(String.format("%08x", codepoint));
+				++i;
+				continue;
+			}
+
+			char ch = Character.toChars(codepoint)[0];
+			if (ch == '\'') {
+				out.append("\\'");
+				continue;
+			}
+			if (ch >= 0x20 && ch < 0x7F) {
+				out.append(ch);
+				continue;
+			}
+
+			switch (ch) {
+			case '\t':
+				out.append("\\t");
+				break;
+			case '\b':
+				out.append("\\b");
+				break;
+			case '\n':
+				out.append("\\n");
+				break;
+			case '\r':
+				out.append("\\r");
+				break;
+			case '\f':
+				out.append("\\f");
+				break;
+			default:
+				out.append("\\u").append(String.format("%04x", codepoint));
+			}
+		}
+		return out;
+	}
 }

--- a/src/main/java/org/tomlj/TomlArray.java
+++ b/src/main/java/org/tomlj/TomlArray.java
@@ -276,13 +276,16 @@ public interface TomlArray {
 
   /**
    * Return a representation of this array using JSON.
-   *
+   * @param optionalIndent Optional integer argument to indent JSON. 
+   *        If provided &  >0, JSON will indent with number of spaces mentioned.
+   *        If provided & <=0, JSON will be serialized (no indents).
+   *        If not provided, JSON will indent with default of 2 spaces.
    * @return A JSON representation of this array.
    */
-	default String toJson() throws Exception {
+	default String toJson(Integer... optionalIndent) throws Exception {
 		StringBuilder builder = new StringBuilder();
 		try {
-			toJson(builder);
+			toJson(builder, optionalIndent);
 		} catch (JSONException e) {
 			throw new JSONException(e);
 		}
@@ -308,9 +311,13 @@ public interface TomlArray {
    * Append a JSON representation of this array to the appendable output.
    *
    * @param appendable The appendable output.
+   * @param optionalIndent Optional integer argument to indent JSON. 
+   *        If provided &  >0, JSON will indent with number of spaces mentioned.
+   *        If provided & <=0, JSON will be serialized (no indents).
+   *        If not provided, JSON will indent with default of 2 spaces.
    * @throws IOException If an IO error occurs.
    */
-  default void toJson(Appendable appendable) throws IOException {
-    JsonSerializer.toJson(this, appendable);
-  }
+	default void toJson(Appendable appendable, Integer... optionalIndent) throws IOException {
+		JsonSerializer.toJson(this, appendable, optionalIndent);
+	}
 }

--- a/src/main/java/org/tomlj/TomlArray.java
+++ b/src/main/java/org/tomlj/TomlArray.java
@@ -13,12 +13,12 @@
 package org.tomlj;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An array of TOML values.
@@ -279,17 +279,31 @@ public interface TomlArray {
    *
    * @return A JSON representation of this array.
    */
-  default String toJson() {
-    StringBuilder builder = new StringBuilder();
-    try {
-      toJson(builder);
-    } catch (IOException e) {
-      // not reachable
-      throw new UncheckedIOException(e);
-    }
-    return builder.toString();
-  }
+	default String toJson() throws Exception {
+		StringBuilder builder = new StringBuilder();
+		try {
+			toJson(builder);
+		} catch (JSONException e) {
+			throw new JSONException(e);
+		}
+		JSONPath.validateJSON(builder.toString());
+		return builder.toString();
+	}
 
+	/**
+	 * Return a Map contaning Key = JSONPath Value = actual TOML value
+	 * 
+	 * @return A Map with JSONPath representation of this Array.
+	 * @throws Exception
+	 */
+	default Map<String, Object> toJsonPath() throws Exception {
+		try {
+			return JSONPath.setJsonPaths(toJson());
+		} catch (Exception e) {
+			throw new JSONException(e);
+		}
+	}
+  
   /**
    * Append a JSON representation of this array to the appendable output.
    *

--- a/src/main/java/org/tomlj/TomlTable.java
+++ b/src/main/java/org/tomlj/TomlTable.java
@@ -1394,14 +1394,17 @@ public interface TomlTable {
 
 	/**
 	 * Return a representation of this table using JSON.
-	 *
+	 * @param optionalIndent Optional integer argument to indent JSON. 
+	 * 	      If provided &  >0, JSON will indent with number of spaces mentioned.
+	 *        If provided & <=0, JSON will be serialized (no indents).
+	 *        If not provided, JSON will indent with default of 2 spaces.
 	 * @return A JSON representation of this table.
 	 * @throws Exception
 	 */
-	default String toJson() throws Exception {
+	default String toJson(Integer... optionalIndent) throws Exception {
 		StringBuilder builder = new StringBuilder();
 		try {
-			toJson(builder);
+			toJson(builder, optionalIndent);
 		} catch (JSONException e) {
 			throw new JSONException(e);
 		}
@@ -1426,12 +1429,14 @@ public interface TomlTable {
 	/**
 	 * Append a JSON representation of this table to the appendable output.
 	 *
-	 * @param appendable
-	 *            The appendable output.
-	 * @throws IOException
-	 *             If an IO error occurs.
+	 * @param appendable The appendable output.
+	 * @param optionalIndent Optional integer argument to indent JSON. 
+	 * 	      If provided &  >0, JSON will indent with number of spaces mentioned.
+	 *        If provided & <=0, JSON will be serialized (no indents).
+	 *        If not provided, JSON will indent with default of 2 spaces.
+	 * @throws IOException If an IO error occurs.
 	 */
-	default void toJson(Appendable appendable) throws IOException {
-		JsonSerializer.toJson(this, appendable);
+	default void toJson(Appendable appendable, Integer... optionalIndent) throws IOException {
+		JsonSerializer.toJson(this, appendable, optionalIndent);
 	}
 }

--- a/src/main/java/org/tomlj/TomlTable.java
+++ b/src/main/java/org/tomlj/TomlTable.java
@@ -15,7 +15,6 @@ package org.tomlj;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -31,1145 +30,1355 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
- * An interface for accessing data stored in Tom's Obvious, Minimal Language (TOML).
+ * An interface for accessing data stored in Tom's Obvious, Minimal Language
+ * (TOML).
  */
 public interface TomlTable {
 
-  /**
-   * @return The number of entries in tis table.
-   */
-  int size();
-
-  /**
-   * @return {@code true} if there are no entries in this table.
-   */
-  boolean isEmpty();
-
-  /**
-   * Check if a key was set in the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.port"}).
-   * @return {@code true} if the key was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean contains(String dottedKey) {
-    requireNonNull(dottedKey);
-    return contains(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a key was set in the TOML document.
-   *
-   * @param path The key path.
-   * @return {@code true} if the key was set in the TOML document.
-   */
-  default boolean contains(List<String> path) {
-    try {
-      return get(path) != null;
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-  }
-
-  /**
-   * Get the keys of this table.
-   *
-   * <p>
-   * The returned set contains only immediate keys to this table, and not dotted keys or key paths. For a complete view
-   * of keys available in the TOML document, use {@link #dottedKeySet()} or {@link #keyPathSet()}.
-   *
-   * @return A set containing the keys of this table.
-   */
-  Set<String> keySet();
-
-  /**
-   * Get all the dotted keys of this table.
-   *
-   * <p>
-   * Paths to intermediary and empty tables are not returned. To include these, use {@link #dottedKeySet(boolean)}.
-   *
-   * @return A set containing all the dotted keys of this table.
-   */
-  default Set<String> dottedKeySet() {
-    return keyPathSet().stream().map(Toml::joinKeyPath).collect(Collectors.toSet());
-  }
-
-  /**
-   * Get all the dotted keys of this table.
-   *
-   * @param includeTables If {@code true}, also include paths to intermediary and empty tables.
-   * @return A set containing all the dotted keys of this table.
-   */
-  default Set<String> dottedKeySet(boolean includeTables) {
-    return keyPathSet(includeTables).stream().map(Toml::joinKeyPath).collect(Collectors.toSet());
-  }
-
-  /**
-   * Get all the paths in this table.
-   *
-   * <p>
-   * Paths to intermediary and empty tables are not returned. To include these, use {@link #keyPathSet(boolean)}.
-   *
-   * @return A set containing all the key paths of this table.
-   */
-  default Set<List<String>> keyPathSet() {
-    return keyPathSet(false);
-  }
-
-  /**
-   * Get all the paths in this table.
-   *
-   * @param includeTables If {@code true}, also include paths to intermediary and empty tables.
-   * @return A set containing all the key paths of this table.
-   */
-  Set<List<String>> keyPathSet(boolean includeTables);
-
-  /**
-   * Get a value from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If any element of the path preceding the final key is not a table.
-   */
-  @Nullable
-  default Object get(String dottedKey) {
-    requireNonNull(dottedKey);
-    return get(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a value from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If any element of the path preceding the final key is not a table.
-   */
-  @Nullable
-  Object get(List<String> path);
-
-  /**
-   * Get the position where a key is defined in the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The input position, or {@code null} if the key was not set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If any element of the path preceding the final key is not a table.
-   */
-  @Nullable
-  default TomlPosition inputPositionOf(String dottedKey) {
-    requireNonNull(dottedKey);
-    return inputPositionOf(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get the position where a key is defined in the TOML document.
-   *
-   * @param path The key path.
-   * @return The input position, or {@code null} if the key was not set in the TOML document.
-   * @throws TomlInvalidTypeException If any element of the path preceding the final key is not a table.
-   */
-  @Nullable
-  TomlPosition inputPositionOf(List<String> path);
-
-  /**
-   * Check if a value in the TOML document is a string.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.hostname"}).
-   * @return {@code true} if the value can be obtained as a string.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isString(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isString(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a string.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a string.
-   */
-  default boolean isString(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof String;
-  }
-
-  /**
-   * Get a string from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.hostname"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a string, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default String getString(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getString(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a string from the TOML document.
-   *
-   * @param path A dotted key (e.g. {@code "server.address.hostname"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a string, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default String getString(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof String)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (String) value;
-  }
-
-  /**
-   * Get a string from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.hostname"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a string, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default String getString(String dottedKey, Supplier<String> defaultValue) {
-    requireNonNull(dottedKey);
-    return getString(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get a string from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not a string, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default String getString(List<String> path, Supplier<String> defaultValue) {
-    requireNonNull(defaultValue);
-    String value = getString(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.get();
-  }
-
-  /**
-   * Check if a value in the TOML document is a long.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return {@code true} if the value can be obtained as a long.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isLong(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isLong(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a long.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a long.
-   */
-  default boolean isLong(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof Long;
-  }
-
-  /**
-   * Get a long from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a long, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default Long getLong(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getLong(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a long from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a long, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default Long getLong(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Long)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (Long) value;
-  }
-
-  /**
-   * Get a long from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a long, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default long getLong(String dottedKey, LongSupplier defaultValue) {
-    requireNonNull(dottedKey);
-    return getLong(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get a long from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not a long, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default long getLong(List<String> path, LongSupplier defaultValue) {
-    requireNonNull(defaultValue);
-    Long value = getLong(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.getAsLong();
-  }
-
-  /**
-   * Check if a value in the TOML document is a double.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return {@code true} if the value can be obtained as a double.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isDouble(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isDouble(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a double.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a double.
-   */
-  default boolean isDouble(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof Double;
-  }
-
-  /**
-   * Get a double from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a double, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default Double getDouble(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getDouble(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a double from the TOML document.
-   *
-   * @param path A dotted key.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a double, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default Double getDouble(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Double)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (Double) value;
-  }
-
-  /**
-   * Get a double from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a double, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default double getDouble(String dottedKey, DoubleSupplier defaultValue) {
-    requireNonNull(dottedKey);
-    return getDouble(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get a double from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not a double, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default double getDouble(List<String> path, DoubleSupplier defaultValue) {
-    requireNonNull(defaultValue);
-    Double value = getDouble(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.getAsDouble();
-  }
-
-  /**
-   * Check if a value in the TOML document is a boolean.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return {@code true} if the value can be obtained as a boolean.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isBoolean(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isBoolean(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a boolean.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a boolean.
-   */
-  default boolean isBoolean(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof Boolean;
-  }
-
-  /**
-   * Get a boolean from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a boolean, or any element of the path preceding
-   *         the final key is not a table.
-   */
-  @Nullable
-  default Boolean getBoolean(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getBoolean(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a boolean from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a boolean, or any element of the path preceding
-   *         the final key is not a table.
-   */
-  @Nullable
-  default Boolean getBoolean(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Boolean)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (Boolean) value;
-  }
-
-  /**
-   * Get a boolean from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a boolean, or any element of the path preceding
-   *         the final key is not a table.
-   */
-  default boolean getBoolean(String dottedKey, BooleanSupplier defaultValue) {
-    requireNonNull(dottedKey);
-    return getBoolean(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get a boolean from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not a boolean, or any element of the path preceding
-   *         the final key is not a table.
-   */
-  default boolean getBoolean(List<String> path, BooleanSupplier defaultValue) {
-    requireNonNull(defaultValue);
-    Boolean value = getBoolean(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.getAsBoolean();
-  }
-
-  /**
-   * Check if a value in the TOML document is an {@link OffsetDateTime}.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return {@code true} if the value can be obtained as an {@link OffsetDateTime}.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isOffsetDateTime(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isOffsetDateTime(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is an {@link OffsetDateTime}.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as an {@link OffsetDateTime}.
-   */
-  default boolean isOffsetDateTime(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof OffsetDateTime;
-  }
-
-  /**
-   * Get an offset date time from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not an {@link OffsetDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  @Nullable
-  default OffsetDateTime getOffsetDateTime(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getOffsetDateTime(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get an offset date time from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not an {@link OffsetDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  @Nullable
-  default OffsetDateTime getOffsetDateTime(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof OffsetDateTime)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (OffsetDateTime) value;
-  }
-
-  /**
-   * Get an offset date time from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not an {@link OffsetDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  default OffsetDateTime getOffsetDateTime(String dottedKey, Supplier<OffsetDateTime> defaultValue) {
-    requireNonNull(dottedKey);
-    return getOffsetDateTime(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get an offset date time from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not an {@link OffsetDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  default OffsetDateTime getOffsetDateTime(List<String> path, Supplier<OffsetDateTime> defaultValue) {
-    requireNonNull(defaultValue);
-    OffsetDateTime value = getOffsetDateTime(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.get();
-  }
-
-  /**
-   * Check if a value in the TOML document is a {@link LocalDateTime}.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return {@code true} if the value can be obtained as a {@link LocalDateTime}.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isLocalDateTime(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isLocalDateTime(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a {@link LocalDateTime}.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a {@link LocalDateTime}.
-   */
-  default boolean isLocalDateTime(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof LocalDateTime;
-  }
-
-  /**
-   * Get a local date time from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  @Nullable
-  default LocalDateTime getLocalDateTime(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getLocalDateTime(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a local date time from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  @Nullable
-  default LocalDateTime getLocalDateTime(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof LocalDateTime)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (LocalDateTime) value;
-  }
-
-  /**
-   * Get a local date time from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  default LocalDateTime getLocalDateTime(String dottedKey, Supplier<LocalDateTime> defaultValue) {
-    requireNonNull(dottedKey);
-    return getLocalDateTime(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get a local date time from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDateTime}, or any element of the
-   *         path preceding the final key is not a table.
-   */
-  default LocalDateTime getLocalDateTime(List<String> path, Supplier<LocalDateTime> defaultValue) {
-    requireNonNull(defaultValue);
-    LocalDateTime value = getLocalDateTime(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.get();
-  }
-
-  /**
-   * Check if a value in the TOML document is a {@link LocalDate}.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return {@code true} if the value can be obtained as a {@link LocalDate}.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isLocalDate(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isLocalDate(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a {@link LocalDate}.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a {@link LocalDate}.
-   */
-  default boolean isLocalDate(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof LocalDate;
-  }
-
-  /**
-   * Get a local date from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDate}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  @Nullable
-  default LocalDate getLocalDate(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getLocalDate(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a local date from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDate}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  @Nullable
-  default LocalDate getLocalDate(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof LocalDate)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (LocalDate) value;
-  }
-
-  /**
-   * Get a local date from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDate}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  default LocalDate getLocalDate(String dottedKey, Supplier<LocalDate> defaultValue) {
-    requireNonNull(dottedKey);
-    return getLocalDate(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get a local date from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalDate}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  default LocalDate getLocalDate(List<String> path, Supplier<LocalDate> defaultValue) {
-    requireNonNull(defaultValue);
-    LocalDate value = getLocalDate(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.get();
-  }
-
-  /**
-   * Check if a value in the TOML document is a {@link LocalTime}.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return {@code true} if the value can be obtained as a {@link LocalTime}.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isLocalTime(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isLocalTime(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a {@link LocalTime}.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a {@link LocalTime}.
-   */
-  default boolean isLocalTime(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof LocalTime;
-  }
-
-  /**
-   * Get a local time from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalTime}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  @Nullable
-  default LocalTime getLocalTime(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getLocalTime(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a local time from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalTime}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  @Nullable
-  default LocalTime getLocalTime(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof LocalTime)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (LocalTime) value;
-  }
-
-  /**
-   * Get a local time from the TOML document, or return a default.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalTime}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  default LocalTime getLocalTime(String dottedKey, Supplier<LocalTime> defaultValue) {
-    requireNonNull(dottedKey);
-    return getLocalTime(Parser.parseDottedKey(dottedKey), defaultValue);
-  }
-
-  /**
-   * Get a local time from the TOML document, or return a default.
-   *
-   * @param path The key path.
-   * @param defaultValue A supplier for the default value.
-   * @return The value, or the default.
-   * @throws TomlInvalidTypeException If the value is present but not a {@link LocalTime}, or any element of the path
-   *         preceding the final key is not a table.
-   */
-  default LocalTime getLocalTime(List<String> path, Supplier<LocalTime> defaultValue) {
-    requireNonNull(defaultValue);
-    LocalTime value = getLocalTime(path);
-    if (value != null) {
-      return value;
-    }
-    return defaultValue.get();
-  }
-
-  /**
-   * Check if a value in the TOML document is an array.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.addresses"}).
-   * @return {@code true} if the value can be obtained as an array.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isArray(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isArray(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is an array.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as an array.
-   */
-  default boolean isArray(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof TomlArray;
-  }
-
-  /**
-   * Get an array from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.addresses"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not an array, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default TomlArray getArray(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getArray(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get an array from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not an array, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default TomlArray getArray(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof TomlArray)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (TomlArray) value;
-  }
-
-  /**
-   * Get an array from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.addresses"}).
-   * @return The value, or an empty list if no list was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not an array, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default TomlArray getArrayOrEmpty(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getArrayOrEmpty(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get an array from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or an empty list if no list was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not an array, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default TomlArray getArrayOrEmpty(List<String> path) {
-    TomlArray value = getArray(path);
-    if (value != null) {
-      return value;
-    }
-    return MutableTomlArray.EMPTY;
-  }
-
-  /**
-   * Check if a value in the TOML document is a table.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address"}).
-   * @return {@code true} if the value can be obtained as a table.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   */
-  default boolean isTable(String dottedKey) {
-    requireNonNull(dottedKey);
-    return isTable(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Check if a value in the TOML document is a table.
-   *
-   * @param path The key path.
-   * @return {@code true} if the value can be obtained as a table.
-   */
-  default boolean isTable(List<String> path) {
-    Object value;
-    try {
-      value = get(path);
-    } catch (TomlInvalidTypeException e) {
-      return false;
-    }
-    return value instanceof TomlTable;
-  }
-
-  /**
-   * Get a table from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address"}).
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a table, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default TomlTable getTable(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getTable(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a table from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or {@code null} if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a table, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  @Nullable
-  default TomlTable getTable(List<String> path) {
-    Object value = get(path);
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof TomlTable)) {
-      throw new TomlInvalidTypeException(
-          "Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
-    }
-    return (TomlTable) value;
-  }
-
-  /**
-   * Get a table from the TOML document.
-   *
-   * @param dottedKey A dotted key (e.g. {@code "server.address.port"}).
-   * @return The value, or an empty table if no value was set in the TOML document.
-   * @throws IllegalArgumentException If the key cannot be parsed.
-   * @throws TomlInvalidTypeException If the value is present but not a table, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default TomlTable getTableOrEmpty(String dottedKey) {
-    requireNonNull(dottedKey);
-    return getTableOrEmpty(Parser.parseDottedKey(dottedKey));
-  }
-
-  /**
-   * Get a table from the TOML document.
-   *
-   * @param path The key path.
-   * @return The value, or an empty table if no value was set in the TOML document.
-   * @throws TomlInvalidTypeException If the value is present but not a table, or any element of the path preceding the
-   *         final key is not a table.
-   */
-  default TomlTable getTableOrEmpty(List<String> path) {
-    TomlTable value = getTable(path);
-    if (value != null) {
-      return value;
-    }
-    return MutableTomlTable.EMPTY;
-  }
-
-  /**
-   * Get the elements of this array as a {@link Map}.
-   *
-   * <p>
-   * Note that this does not do a deep conversion. If this array contains tables or arrays, they will be of type
-   * {@link TomlTable} or {@link TomlArray} respectively.
-   *
-   * @return The elements of this array as a {@link Map}.
-   */
-  Map<String, Object> toMap();
-
-  /**
-   * Return a representation of this table using JSON.
-   *
-   * @return A JSON representation of this table.
-   */
-  default String toJson() {
-    StringBuilder builder = new StringBuilder();
-    try {
-      toJson(builder);
-    } catch (IOException e) {
-      // not reachable
-      throw new UncheckedIOException(e);
-    }
-    return builder.toString();
-  }
-
-  /**
-   * Append a JSON representation of this table to the appendable output.
-   *
-   * @param appendable The appendable output.
-   * @throws IOException If an IO error occurs.
-   */
-  default void toJson(Appendable appendable) throws IOException {
-    JsonSerializer.toJson(this, appendable);
-  }
+	/**
+	 * @return The number of entries in tis table.
+	 */
+	int size();
+
+	/**
+	 * @return {@code true} if there are no entries in this table.
+	 */
+	boolean isEmpty();
+
+	/**
+	 * Check if a key was set in the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.port"}).
+	 * @return {@code true} if the key was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean contains(String dottedKey) {
+		requireNonNull(dottedKey);
+		return contains(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a key was set in the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the key was set in the TOML document.
+	 */
+	default boolean contains(List<String> path) {
+		try {
+			return get(path) != null;
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Get the keys of this table.
+	 *
+	 * <p>
+	 * The returned set contains only immediate keys to this table, and not dotted
+	 * keys or key paths. For a complete view of keys available in the TOML
+	 * document, use {@link #dottedKeySet()} or {@link #keyPathSet()}.
+	 *
+	 * @return A set containing the keys of this table.
+	 */
+	Set<String> keySet();
+
+	/**
+	 * Get all the dotted keys of this table.
+	 *
+	 * <p>
+	 * Paths to intermediary and empty tables are not returned. To include these,
+	 * use {@link #dottedKeySet(boolean)}.
+	 *
+	 * @return A set containing all the dotted keys of this table.
+	 */
+	default Set<String> dottedKeySet() {
+		return keyPathSet().stream().map(Toml::joinKeyPath).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Get all the dotted keys of this table.
+	 *
+	 * @param includeTables
+	 *            If {@code true}, also include paths to intermediary and empty
+	 *            tables.
+	 * @return A set containing all the dotted keys of this table.
+	 */
+	default Set<String> dottedKeySet(boolean includeTables) {
+		return keyPathSet(includeTables).stream().map(Toml::joinKeyPath).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Get all the paths in this table.
+	 *
+	 * <p>
+	 * Paths to intermediary and empty tables are not returned. To include these,
+	 * use {@link #keyPathSet(boolean)}.
+	 *
+	 * @return A set containing all the key paths of this table.
+	 */
+	default Set<List<String>> keyPathSet() {
+		return keyPathSet(false);
+	}
+
+	/**
+	 * Get all the paths in this table.
+	 *
+	 * @param includeTables
+	 *            If {@code true}, also include paths to intermediary and empty
+	 *            tables.
+	 * @return A set containing all the key paths of this table.
+	 */
+	Set<List<String>> keyPathSet(boolean includeTables);
+
+	/**
+	 * Get a value from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If any element of the path preceding the final key is not a
+	 *             table.
+	 */
+	@Nullable
+	default Object get(String dottedKey) {
+		requireNonNull(dottedKey);
+		return get(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a value from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If any element of the path preceding the final key is not a
+	 *             table.
+	 */
+	@Nullable
+	Object get(List<String> path);
+
+	/**
+	 * Get the position where a key is defined in the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The input position, or {@code null} if the key was not set in the
+	 *         TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If any element of the path preceding the final key is not a
+	 *             table.
+	 */
+	@Nullable
+	default TomlPosition inputPositionOf(String dottedKey) {
+		requireNonNull(dottedKey);
+		return inputPositionOf(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get the position where a key is defined in the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The input position, or {@code null} if the key was not set in the
+	 *         TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If any element of the path preceding the final key is not a
+	 *             table.
+	 */
+	@Nullable
+	TomlPosition inputPositionOf(List<String> path);
+
+	/**
+	 * Check if a value in the TOML document is a string.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.hostname"}).
+	 * @return {@code true} if the value can be obtained as a string.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isString(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isString(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a string.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a string.
+	 */
+	default boolean isString(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof String;
+	}
+
+	/**
+	 * Get a string from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.hostname"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a string, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default String getString(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getString(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a string from the TOML document.
+	 *
+	 * @param path
+	 *            A dotted key (e.g. {@code "server.address.hostname"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a string, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default String getString(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof String)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (String) value;
+	}
+
+	/**
+	 * Get a string from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.hostname"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a string, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default String getString(String dottedKey, Supplier<String> defaultValue) {
+		requireNonNull(dottedKey);
+		return getString(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get a string from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a string, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default String getString(List<String> path, Supplier<String> defaultValue) {
+		requireNonNull(defaultValue);
+		String value = getString(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.get();
+	}
+
+	/**
+	 * Check if a value in the TOML document is a long.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return {@code true} if the value can be obtained as a long.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isLong(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isLong(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a long.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a long.
+	 */
+	default boolean isLong(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof Long;
+	}
+
+	/**
+	 * Get a long from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a long, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default Long getLong(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getLong(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a long from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a long, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default Long getLong(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof Long)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (Long) value;
+	}
+
+	/**
+	 * Get a long from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a long, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default long getLong(String dottedKey, LongSupplier defaultValue) {
+		requireNonNull(dottedKey);
+		return getLong(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get a long from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a long, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default long getLong(List<String> path, LongSupplier defaultValue) {
+		requireNonNull(defaultValue);
+		Long value = getLong(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.getAsLong();
+	}
+
+	/**
+	 * Check if a value in the TOML document is a double.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return {@code true} if the value can be obtained as a double.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isDouble(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isDouble(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a double.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a double.
+	 */
+	default boolean isDouble(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof Double;
+	}
+
+	/**
+	 * Get a double from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a double, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default Double getDouble(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getDouble(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a double from the TOML document.
+	 *
+	 * @param path
+	 *            A dotted key.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a double, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default Double getDouble(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof Double)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (Double) value;
+	}
+
+	/**
+	 * Get a double from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a double, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default double getDouble(String dottedKey, DoubleSupplier defaultValue) {
+		requireNonNull(dottedKey);
+		return getDouble(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get a double from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a double, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default double getDouble(List<String> path, DoubleSupplier defaultValue) {
+		requireNonNull(defaultValue);
+		Double value = getDouble(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.getAsDouble();
+	}
+
+	/**
+	 * Check if a value in the TOML document is a boolean.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return {@code true} if the value can be obtained as a boolean.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isBoolean(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isBoolean(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a boolean.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a boolean.
+	 */
+	default boolean isBoolean(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof Boolean;
+	}
+
+	/**
+	 * Get a boolean from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a boolean, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default Boolean getBoolean(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getBoolean(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a boolean from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a boolean, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default Boolean getBoolean(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof Boolean)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (Boolean) value;
+	}
+
+	/**
+	 * Get a boolean from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a boolean, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default boolean getBoolean(String dottedKey, BooleanSupplier defaultValue) {
+		requireNonNull(dottedKey);
+		return getBoolean(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get a boolean from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a boolean, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default boolean getBoolean(List<String> path, BooleanSupplier defaultValue) {
+		requireNonNull(defaultValue);
+		Boolean value = getBoolean(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.getAsBoolean();
+	}
+
+	/**
+	 * Check if a value in the TOML document is an {@link OffsetDateTime}.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return {@code true} if the value can be obtained as an
+	 *         {@link OffsetDateTime}.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isOffsetDateTime(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isOffsetDateTime(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is an {@link OffsetDateTime}.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as an
+	 *         {@link OffsetDateTime}.
+	 */
+	default boolean isOffsetDateTime(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof OffsetDateTime;
+	}
+
+	/**
+	 * Get an offset date time from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an {@link OffsetDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default OffsetDateTime getOffsetDateTime(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getOffsetDateTime(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get an offset date time from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an {@link OffsetDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default OffsetDateTime getOffsetDateTime(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof OffsetDateTime)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (OffsetDateTime) value;
+	}
+
+	/**
+	 * Get an offset date time from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an {@link OffsetDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default OffsetDateTime getOffsetDateTime(String dottedKey, Supplier<OffsetDateTime> defaultValue) {
+		requireNonNull(dottedKey);
+		return getOffsetDateTime(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get an offset date time from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an {@link OffsetDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default OffsetDateTime getOffsetDateTime(List<String> path, Supplier<OffsetDateTime> defaultValue) {
+		requireNonNull(defaultValue);
+		OffsetDateTime value = getOffsetDateTime(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.get();
+	}
+
+	/**
+	 * Check if a value in the TOML document is a {@link LocalDateTime}.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return {@code true} if the value can be obtained as a {@link LocalDateTime}.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isLocalDateTime(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isLocalDateTime(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a {@link LocalDateTime}.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a {@link LocalDateTime}.
+	 */
+	default boolean isLocalDateTime(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof LocalDateTime;
+	}
+
+	/**
+	 * Get a local date time from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default LocalDateTime getLocalDateTime(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getLocalDateTime(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a local date time from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default LocalDateTime getLocalDateTime(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof LocalDateTime)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (LocalDateTime) value;
+	}
+
+	/**
+	 * Get a local date time from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default LocalDateTime getLocalDateTime(String dottedKey, Supplier<LocalDateTime> defaultValue) {
+		requireNonNull(dottedKey);
+		return getLocalDateTime(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get a local date time from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDateTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default LocalDateTime getLocalDateTime(List<String> path, Supplier<LocalDateTime> defaultValue) {
+		requireNonNull(defaultValue);
+		LocalDateTime value = getLocalDateTime(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.get();
+	}
+
+	/**
+	 * Check if a value in the TOML document is a {@link LocalDate}.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return {@code true} if the value can be obtained as a {@link LocalDate}.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isLocalDate(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isLocalDate(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a {@link LocalDate}.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a {@link LocalDate}.
+	 */
+	default boolean isLocalDate(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof LocalDate;
+	}
+
+	/**
+	 * Get a local date from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDate}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default LocalDate getLocalDate(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getLocalDate(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a local date from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDate}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default LocalDate getLocalDate(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof LocalDate)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (LocalDate) value;
+	}
+
+	/**
+	 * Get a local date from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDate}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default LocalDate getLocalDate(String dottedKey, Supplier<LocalDate> defaultValue) {
+		requireNonNull(dottedKey);
+		return getLocalDate(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get a local date from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalDate}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default LocalDate getLocalDate(List<String> path, Supplier<LocalDate> defaultValue) {
+		requireNonNull(defaultValue);
+		LocalDate value = getLocalDate(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.get();
+	}
+
+	/**
+	 * Check if a value in the TOML document is a {@link LocalTime}.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return {@code true} if the value can be obtained as a {@link LocalTime}.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isLocalTime(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isLocalTime(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a {@link LocalTime}.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a {@link LocalTime}.
+	 */
+	default boolean isLocalTime(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof LocalTime;
+	}
+
+	/**
+	 * Get a local time from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default LocalTime getLocalTime(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getLocalTime(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a local time from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	@Nullable
+	default LocalTime getLocalTime(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof LocalTime)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (LocalTime) value;
+	}
+
+	/**
+	 * Get a local time from the TOML document, or return a default.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default LocalTime getLocalTime(String dottedKey, Supplier<LocalTime> defaultValue) {
+		requireNonNull(dottedKey);
+		return getLocalTime(Parser.parseDottedKey(dottedKey), defaultValue);
+	}
+
+	/**
+	 * Get a local time from the TOML document, or return a default.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @param defaultValue
+	 *            A supplier for the default value.
+	 * @return The value, or the default.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a {@link LocalTime}, or any
+	 *             element of the path preceding the final key is not a table.
+	 */
+	default LocalTime getLocalTime(List<String> path, Supplier<LocalTime> defaultValue) {
+		requireNonNull(defaultValue);
+		LocalTime value = getLocalTime(path);
+		if (value != null) {
+			return value;
+		}
+		return defaultValue.get();
+	}
+
+	/**
+	 * Check if a value in the TOML document is an array.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.addresses"}).
+	 * @return {@code true} if the value can be obtained as an array.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isArray(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isArray(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is an array.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as an array.
+	 */
+	default boolean isArray(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof TomlArray;
+	}
+
+	/**
+	 * Get an array from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.addresses"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an array, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default TomlArray getArray(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getArray(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get an array from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an array, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default TomlArray getArray(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof TomlArray)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (TomlArray) value;
+	}
+
+	/**
+	 * Get an array from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.addresses"}).
+	 * @return The value, or an empty list if no list was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an array, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default TomlArray getArrayOrEmpty(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getArrayOrEmpty(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get an array from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or an empty list if no list was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not an array, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default TomlArray getArrayOrEmpty(List<String> path) {
+		TomlArray value = getArray(path);
+		if (value != null) {
+			return value;
+		}
+		return MutableTomlArray.EMPTY;
+	}
+
+	/**
+	 * Check if a value in the TOML document is a table.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address"}).
+	 * @return {@code true} if the value can be obtained as a table.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 */
+	default boolean isTable(String dottedKey) {
+		requireNonNull(dottedKey);
+		return isTable(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Check if a value in the TOML document is a table.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return {@code true} if the value can be obtained as a table.
+	 */
+	default boolean isTable(List<String> path) {
+		Object value;
+		try {
+			value = get(path);
+		} catch (TomlInvalidTypeException e) {
+			return false;
+		}
+		return value instanceof TomlTable;
+	}
+
+	/**
+	 * Get a table from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address"}).
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a table, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default TomlTable getTable(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getTable(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a table from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or {@code null} if no value was set in the TOML document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a table, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	@Nullable
+	default TomlTable getTable(List<String> path) {
+		Object value = get(path);
+		if (value == null) {
+			return null;
+		}
+		if (!(value instanceof TomlTable)) {
+			throw new TomlInvalidTypeException(
+					"Value of '" + Toml.joinKeyPath(path) + "' is a " + TomlType.typeNameFor(value));
+		}
+		return (TomlTable) value;
+	}
+
+	/**
+	 * Get a table from the TOML document.
+	 *
+	 * @param dottedKey
+	 *            A dotted key (e.g. {@code "server.address.port"}).
+	 * @return The value, or an empty table if no value was set in the TOML
+	 *         document.
+	 * @throws IllegalArgumentException
+	 *             If the key cannot be parsed.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a table, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default TomlTable getTableOrEmpty(String dottedKey) {
+		requireNonNull(dottedKey);
+		return getTableOrEmpty(Parser.parseDottedKey(dottedKey));
+	}
+
+	/**
+	 * Get a table from the TOML document.
+	 *
+	 * @param path
+	 *            The key path.
+	 * @return The value, or an empty table if no value was set in the TOML
+	 *         document.
+	 * @throws TomlInvalidTypeException
+	 *             If the value is present but not a table, or any element of the
+	 *             path preceding the final key is not a table.
+	 */
+	default TomlTable getTableOrEmpty(List<String> path) {
+		TomlTable value = getTable(path);
+		if (value != null) {
+			return value;
+		}
+		return MutableTomlTable.EMPTY;
+	}
+
+	/**
+	 * Get the elements of this array as a {@link Map}.
+	 *
+	 * <p>
+	 * Note that this does not do a deep conversion. If this array contains tables
+	 * or arrays, they will be of type {@link TomlTable} or {@link TomlArray}
+	 * respectively.
+	 *
+	 * @return The elements of this array as a {@link Map}.
+	 */
+	Map<String, Object> toMap();
+
+	/**
+	 * Return a representation of this table using JSON.
+	 *
+	 * @return A JSON representation of this table.
+	 * @throws Exception
+	 */
+	default String toJson() throws Exception {
+		StringBuilder builder = new StringBuilder();
+		try {
+			toJson(builder);
+		} catch (JSONException e) {
+			throw new JSONException(e);
+		}
+		validateJSON(builder.toString());
+		return builder.toString();
+	}
+
+	/**
+	 * Tries to validate a JSON
+	 * 
+	 * @param a
+	 *            JSON as String
+	 */
+	default void validateJSON(String Json) throws JSONException {
+		try {
+			JSONPath.validateJSON(Json);
+		} catch (JSONException e) {
+			throw new JSONException(e);
+		}
+	}
+
+	/**
+	 * Return a Map contaning Key = JSONPath Value = actual TOML value
+	 * 
+	 * @param Json
+	 *            A String JSON
+	 * @return A Map with JSONPath representation of this table.
+	 */
+	default Map<String, Object> toJsonPath(String Json) throws JSONException {
+		try {
+			return JSONPath.setJsonPaths(Json);
+		} catch (JSONException e) {
+			throw new JSONException(e);
+		}
+	}
+
+	/**
+	 * Append a JSON representation of this table to the appendable output.
+	 *
+	 * @param appendable
+	 *            The appendable output.
+	 * @throws IOException
+	 *             If an IO error occurs.
+	 */
+	default void toJson(Appendable appendable) throws IOException {
+		JsonSerializer.toJson(this, appendable);
+	}
 }

--- a/src/main/java/org/tomlj/TomlType.java
+++ b/src/main/java/org/tomlj/TomlType.java
@@ -19,7 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Optional;
 
-enum TomlType {
+public enum TomlType {
   STRING("string", String.class),
   INTEGER("integer", Long.class),
   FLOAT("float", Double.class),
@@ -47,7 +47,7 @@ enum TomlType {
     return Arrays.stream(values()).filter(t -> t.clazz.isAssignableFrom(clazz)).findAny();
   }
 
-  static String typeNameFor(Object obj) {
+  public static String typeNameFor(Object obj) {
     return typeNameForClass(obj.getClass());
   }
 

--- a/src/main/java/org/tomlj/TomlType.java
+++ b/src/main/java/org/tomlj/TomlType.java
@@ -19,7 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Optional;
 
-public enum TomlType {
+enum TomlType {
   STRING("string", String.class),
   INTEGER("integer", Long.class),
   FLOAT("float", Double.class),
@@ -47,7 +47,7 @@ public enum TomlType {
     return Arrays.stream(values()).filter(t -> t.clazz.isAssignableFrom(clazz)).findAny();
   }
 
-  public static String typeNameFor(Object obj) {
+  static String typeNameFor(Object obj) {
     return typeNameForClass(obj.getClass());
   }
 

--- a/src/main/java/org/tomlj/ValueVisitor.java
+++ b/src/main/java/org/tomlj/ValueVisitor.java
@@ -78,7 +78,7 @@ final class ValueVisitor extends TomlParserBaseVisitor<Object> {
 
   private Double toDouble(String s, ParserRuleContext ctx) {
     try {
-      Double value = Double.valueOf(s);
+      double value = Double.parseDouble(s);
       if (value == Double.POSITIVE_INFINITY || value == Double.NEGATIVE_INFINITY) {
         throw new TomlParseError("Float is too large", new TomlPosition(ctx));
       }

--- a/src/test/java/org/tomlj/JsonSerializer.java
+++ b/src/test/java/org/tomlj/JsonSerializer.java
@@ -19,47 +19,9 @@ import org.tomlj.Toml;
 import org.tomlj.TomlParseResult;
 
 class JsonSerializer {
-
-	@Test
-	void shouldPassEscapeChar(){
-		String TOML = "winpath = 'C:\\Users\\nodejs\\templates'";
-		String ExpectedResult = 
-				"{\r\n" + 
-				"  \"winpath\" : \"C:\\\\Users\\\\nodejs\\\\templates\"\r\n" + 
-				"}";
-		TomlParseResult toml = Toml.parse(TOML);
-		String sJson = toml.toJson();
-		assertEquals(ExpectedResult, sJson);
-	}
 	
 	@Test
-	void shouldBeOrderedJson(){
-		String TOML = 
-				"Name = { First = \"John\", Last = \"Doe\" }\r\n" + 
-				"Company = { Name = \"GitHub\" }\r\n" + 
-				"Phone = 8123456789\r\n" + 
-				"DateOfBirth = 1993-08-04T15:05:00Z";
-		
-		String ExpectedResult = 
-				"{\r\n" + 
-				"  \"Name\" : {\r\n" + 
-				"    \"First\" : \"John\",\r\n" + 
-				"    \"Last\" : \"Doe\"\r\n" + 
-				"  },\r\n" + 
-				"  \"Company\" : {\r\n" + 
-				"    \"Name\" : \"GitHub\"\r\n" + 
-				"  },\r\n" + 
-				"  \"Phone\" : 8123456789,\r\n" + 
-				"  \"DateOfBirth\" : \"1993-08-04T15:05Z\"\r\n" + 
-				"}";
-		
-		TomlParseResult toml = Toml.parse(TOML);
-		String sJson = toml.toJson();
-		assertEquals(ExpectedResult, sJson);
-	}
-	
-    @Test
-	void shouldGenerateJsonArray(){
+	void shouldGenerateJsonArrayofMixedDataType(){
 		String TOML = 
 				"[array]\r\n" + 
 				"key1 = [ 1993-08-04T15:05:00Z, 15:05:00, 2014-01-03T23:28:56.782Z, 15:06:00 ]";
@@ -76,6 +38,94 @@ class JsonSerializer {
 				"}\r\n" + 
 				"\r\n" + 
 				"";
+		TomlParseResult toml = Toml.parse(TOML);
+		String sJson = toml.toJson();
+		
+		assertEquals(ExpectedResult, sJson);
+	}
+	
+	@Test
+	void shouldGenerateJsonArrayofOffsetDateTimeDataType(){
+		
+		String TOML = "key1 = [ 1979-05-27T00:32:00.999999-07:00, 1979-05-27T00:32:00.999999-07:00, 1979-05-27T00:32:00.999999-07:00, 1979-05-27T00:32:00.999999-07:00 ]";
+		String ExpectedResult = 
+				"{\r\n" + 
+				"  \"key1\" : [\r\n" + 
+				"    \"1979-05-27T00:32:00.999999-07:00\",\r\n" + 
+				"    \"1979-05-27T00:32:00.999999-07:00\",\r\n" + 
+				"    \"1979-05-27T00:32:00.999999-07:00\",\r\n" + 
+				"    \"1979-05-27T00:32:00.999999-07:00\"\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n" + 
+				"\r\n" + 
+				"";
+		
+		TomlParseResult toml = Toml.parse(TOML);
+		String sJson = toml.toJson();
+		
+		assertEquals(ExpectedResult, sJson);
+	}
+	
+	@Test
+	void shouldGenerateJsonArrayofLocalDateTimeDataType(){
+		
+		String TOML = "key1 = [1979-05-27T07:32:00, 1979-05-27T07:32:00, 1979-05-27T07:32:00, 1979-05-27T07:32:00 ]";
+		String ExpectedResult = 
+				"{\r\n" + 
+				"  \"key1\": [\r\n" + 
+				"    \"1979-05-27T07:32:00\",\r\n" + 
+				"    \"1979-05-27T07:32:00\",\r\n" + 
+				"    \"1979-05-27T07:32:00\",\r\n" + 
+				"    \"1979-05-27T07:32:00\"\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n" + 
+				"\r\n" + 
+				"";
+		
+		TomlParseResult toml = Toml.parse(TOML);
+		String sJson = toml.toJson();
+		
+		assertEquals(ExpectedResult, sJson);
+	}
+	
+	@Test
+	void shouldGenerateJsonArrayofLocalDateDataType(){
+		
+		String TOML = "key1 = [1979-05-27, 1979-05-27, 1979-05-27, 1979-05-27 ]";
+		String ExpectedResult = 
+				"{\r\n" + 
+				"  \"key1\": [\r\n" + 
+				"    \"1979-05-27\",\r\n" + 
+				"    \"1979-05-27\",\r\n" + 
+				"    \"1979-05-27\",\r\n" + 
+				"    \"1979-05-27\"\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n" + 
+				"\r\n" + 
+				"";
+		
+		TomlParseResult toml = Toml.parse(TOML);
+		String sJson = toml.toJson();
+		
+		assertEquals(ExpectedResult, sJson);
+	}
+	
+	@Test
+	void shouldGenerateJsonArrayofLocalTimeDataType(){
+		
+		String TOML = "key1 = [00:32:00.999999, 00:32:00.999999, 00:32:00.999999, 00:32:00.999999 ]";
+		String ExpectedResult = 
+				"{\r\n" + 
+				"  \"key1\": [\r\n" + 
+				"    \"00:32:00.999999\",\r\n" + 
+				"    \"00:32:00.999999\",\r\n" + 
+				"    \"00:32:00.999999\",\r\n" + 
+				"    \"00:32:00.999999\"\r\n" + 
+				"  ]\r\n" + 
+				"}\r\n" + 
+				"\r\n" + 
+				"";
+		
 		TomlParseResult toml = Toml.parse(TOML);
 		String sJson = toml.toJson();
 		

--- a/src/test/java/org/tomlj/JsonSerializer.java
+++ b/src/test/java/org/tomlj/JsonSerializer.java
@@ -21,7 +21,7 @@ import org.tomlj.TomlParseResult;
 class JsonSerializer {
 
 	@Test
-	void shouldPassEscapeChar() throws Exception {
+	void shouldPassEscapeChar(){
 		String TOML = "winpath = 'C:\\Users\\nodejs\\templates'";
 		String ExpectedResult = 
 				"{\r\n" + 
@@ -33,7 +33,7 @@ class JsonSerializer {
 	}
 	
 	@Test
-	void shouldBeOrderedJson() throws Exception {
+	void shouldBeOrderedJson(){
 		String TOML = 
 				"Name = { First = \"John\", Last = \"Doe\" }\r\n" + 
 				"Company = { Name = \"GitHub\" }\r\n" + 
@@ -55,6 +55,30 @@ class JsonSerializer {
 		
 		TomlParseResult toml = Toml.parse(TOML);
 		String sJson = toml.toJson();
+		assertEquals(ExpectedResult, sJson);
+	}
+	
+    @Test
+	void shouldGenerateJsonArray(){
+		String TOML = 
+				"[array]\r\n" + 
+				"key1 = [ 1993-08-04T15:05:00Z, 15:05:00, 2014-01-03T23:28:56.782Z, 15:06:00 ]";
+		String ExpectedResult = 
+				"{\r\n" + 
+				"  \"array\" : {\r\n" + 
+				"    \"key1\" : [\r\n" + 
+				"      \"1993-08-04T15:05Z\",\r\n" + 
+				"      \"15:05\",\r\n" + 
+				"      \"2014-01-03T23:28:56.782Z\",\r\n" + 
+				"      \"15:06\"\r\n" + 
+				"    ]\r\n" + 
+				"  }\r\n" + 
+				"}\r\n" + 
+				"\r\n" + 
+				"";
+		TomlParseResult toml = Toml.parse(TOML);
+		String sJson = toml.toJson();
+		
 		assertEquals(ExpectedResult, sJson);
 	}
 }

--- a/src/test/java/org/tomlj/JsonSerializer.java
+++ b/src/test/java/org/tomlj/JsonSerializer.java
@@ -21,12 +21,38 @@ import org.tomlj.TomlParseResult;
 class JsonSerializer {
 
 	@Test
-	void shouldPassEscapeChar() {
+	void shouldPassEscapeChar() throws Exception {
 		String TOML = "winpath = 'C:\\Users\\nodejs\\templates'";
 		String ExpectedResult = 
 				"{\r\n" + 
-				"    \"winpath\": \"C:\\\\Users\\\\nodejs\\\\templates\"\r\n" + 
+				"  \"winpath\" : \"C:\\\\Users\\\\nodejs\\\\templates\"\r\n" + 
 				"}";
+		TomlParseResult toml = Toml.parse(TOML);
+		String sJson = toml.toJson();
+		assertEquals(ExpectedResult, sJson);
+	}
+	
+	@Test
+	void shouldBeOrderedJson() throws Exception {
+		String TOML = 
+				"Name = { First = \"John\", Last = \"Doe\" }\r\n" + 
+				"Company = { Name = \"GitHub\" }\r\n" + 
+				"Phone = 8123456789\r\n" + 
+				"DateOfBirth = 1993-08-04T15:05:00Z";
+		
+		String ExpectedResult = 
+				"{\r\n" + 
+				"  \"Name\" : {\r\n" + 
+				"    \"First\" : \"John\",\r\n" + 
+				"    \"Last\" : \"Doe\"\r\n" + 
+				"  },\r\n" + 
+				"  \"Company\" : {\r\n" + 
+				"    \"Name\" : \"GitHub\"\r\n" + 
+				"  },\r\n" + 
+				"  \"Phone\" : 8123456789,\r\n" + 
+				"  \"DateOfBirth\" : \"1993-08-04T15:05Z\"\r\n" + 
+				"}";
+		
 		TomlParseResult toml = Toml.parse(TOML);
 		String sJson = toml.toJson();
 		assertEquals(ExpectedResult, sJson);

--- a/src/test/java/org/tomlj/JsonSerializer.java
+++ b/src/test/java/org/tomlj/JsonSerializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.tomlj;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+
+class JsonSerializer {
+
+	@Test
+	void shouldPassEscapeChar() {
+		String TOML = "winpath = 'C:\\Users\\nodejs\\templates'";
+		String ExpectedResult = 
+				"{\r\n" + 
+				"    \"winpath\": \"C:\\\\Users\\\\nodejs\\\\templates\"\r\n" + 
+				"}";
+		TomlParseResult toml = Toml.parse(TOML);
+		String sJson = toml.toJson();
+		assertEquals(ExpectedResult, sJson);
+	}
+}

--- a/src/test/java/org/tomlj/MutableTomlTableTest.java
+++ b/src/test/java/org/tomlj/MutableTomlTableTest.java
@@ -110,7 +110,7 @@ class MutableTomlTableTest {
   }
 
   @Test
-  void ignoresWhitespaceInUnquotedKeys() {
+  void ignoresWhitespaceAroundUnquotedKeys() {
     MutableTomlTable table = new MutableTomlTable();
     table.set("foo.bar", 4, positionAt(5, 3));
     assertEquals(Long.valueOf(4), table.getLong(" foo . bar"));

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -561,6 +561,48 @@ class TomlTest {
     assertTrue(result3.hasErrors());
   }
 
+  @Test
+  void testSpacesInKeys() throws Exception {
+    TomlParseResult result1 = Toml.parse("\"Dog type\" = \"pug\"");
+    assertFalse(result1.hasErrors(), () -> joinErrors(result1));
+    assertEquals("pug", result1.getString("\"Dog type\""));
+    assertEquals("pug", result1.getString("Dog type"));
+
+    TomlParseResult result2 = Toml.parse("[\"Dog 1\"]\n  type = \"pug\"");
+    assertFalse(result2.hasErrors(), () -> joinErrors(result2));
+    assertEquals("pug", result2.getString("\"Dog 1\".type"));
+    assertEquals("pug", result2.getString("Dog 1.type"));
+
+    TomlParseResult result3 = Toml.parse("[pets.\"Dog 1\"]\n  type = \"pug\"");
+    assertFalse(result3.hasErrors(), () -> joinErrors(result3));
+    assertEquals("pug", result3.getString("pets.\"Dog 1\".type"));
+    assertEquals("pug", result3.getString("pets.Dog 1.type"));
+    assertEquals("pug", result3.getString("pets.Dog 1  .type"));
+    assertEquals("pug", result3.getString("pets.  Dog 1.type"));
+  }
+
+  @Test
+  void testQuotesInJson() throws Exception {
+    TomlParseResult result1 = Toml.parse("key = \"this is 'a test' with single quotes\"");
+    assertFalse(result1.hasErrors());
+    assertEquals("{\n  \"key\" : \"this is 'a test' with single quotes\"\n}\n", result1.toJson());
+
+    TomlParseResult result2 = Toml.parse("[\"dog 'type'\"]\ntype = \"pug\"");
+    assertFalse(result2.hasErrors());
+    assertEquals("{\n  \"dog 'type'\" : {\n    \"type\" : \"pug\"\n  }\n}\n", result2.toJson());
+
+    TomlParseResult result3 = Toml.parse("key = \"this is \\\"a test\\\" with double quotes\"");
+    assertFalse(result3.hasErrors());
+    assertEquals("{\n  \"key\" : \"this is \\\"a test\\\" with double quotes\"\n}\n", result3.toJson());
+  }
+
+  @Test
+  void testBackslashesInJson() throws Exception {
+    TomlParseResult result1 = Toml.parse("path = 'C:\\Users\\dog\\catsihate'");
+    assertFalse(result1.hasErrors(), () -> joinErrors(result1));
+    assertEquals("{\n  \"path\" : \"C:\\\\Users\\\\dog\\\\catsihate\"\n}\n", result1.toJson());
+  }
+
   private String joinErrors(TomlParseResult result) {
     return result.errors().stream().map(TomlParseError::toString).collect(Collectors.joining("\n"));
   }


### PR DESCRIPTION
**_Fixes_** for #1 #2 and #3  

**Additional**: JSON is now created as per sequence of TOML and is now validated after creation. On invalid JSON creation, `JSONException` is thrown immediately.

**Additional**: Added new `parse()` methods with boolean parameter _( which decides the behavior of `parse()` )_. Default `parse()` methods will pass "**false**" (_existing functionality of parser_). New methods can have additional parameter set as: 
- _true_:  Throws Parsing issue immediately
- _false_: Default behaviour of the parser

**Additional**: `toMap()` does not drills deep in complex data types. However, if needed a complete Map of TOML, `toJsonPath()` creates it with <JSONPath, Value>, (maintains sequence as per TOML definition). Below is an example to what it does!

_Sample TOML:_
```
[table.subtable1]
  key                 = "table.subtable1 - another value"
  site."google.com"   = "table.subtable1 - site.\"google.com\""
  'quoted "value"'    = 'table.subtable1 - quoted "value"'
  site.'facebook.com' = "table.subtable1 - site.'facebook.com'"

[table."subtable 2"]
  key                 = "table.\"subtable 2\" - another value"
  site."google.com"   = "table.\"subtable 2\" - site.\"google.com\""
  'quoted "value"'    = 'table.\"subtable 2\" - quoted "value"'
  site.'facebook.com' = "table.\"subtable 2\" - site.'facebook.com'"

[table.'subtable 3']
  key                   = "table.\"subtable 3\" - another value"
  site . "google.com"   = "table.\"subtable 3\" - site.\"google.com\""
  'quoted "value"'      = 'table.\"subtable 3\" - quoted "value"'
  site . 'facebook.com' = "table.\"subtable 3\" - site.'facebook.com'"
  
[array]
key1 = [ 1, 2, 3 ]
key2 = [ "red", "yellow", "green" ]
key3 = [ [ 1, 2 ], [3, 4, 5] ]
key4 = [ [ 1, 2 ], ["a", "b", "c"] ] # this is ok

[[fruit]]
name = "apple"

[fruit.physical]
color = "red"
shape = "round"

[[fruit.variety]]
name = "red delicious"

[[fruit.variety]]
  name = "granny smith"

[[fruit]]
name = "banana"

[[fruit.variety]]
name = "plantain"
```
_Map created:_
```
$.[table].[subtable1].[key] => table.subtable1 - another value
$.[table].[subtable1].[site].[google.com] => table.subtable1 - site."google.com"
$.[table].[subtable1].[site].[facebook.com] => table.subtable1 - site.'facebook.com'
$.[table].[subtable1].[quoted "value"] => table.subtable1 - quoted "value"
$.[table].[subtable 2].[key] => table."subtable 2" - another value
$.[table].[subtable 2].[site].[google.com] => table."subtable 2" - site."google.com"
$.[table].[subtable 2].[site].[facebook.com] => table."subtable 2" - site.'facebook.com'
$.[table].[subtable 2].[quoted "value"] => table.\"subtable 2\" - quoted "value"
$.[table].[subtable 3].[key] => table."subtable 3" - another value
$.[table].[subtable 3].[site].[google.com] => table."subtable 3" - site."google.com"
$.[table].[subtable 3].[site].[facebook.com] => table."subtable 3" - site.'facebook.com'
$.[table].[subtable 3].[quoted "value"] => table.\"subtable 3\" - quoted "value"
$.[array].[key1][0] => 1
$.[array].[key1][1] => 2
$.[array].[key1][2] => 3
$.[array].[key2][0] => red
$.[array].[key2][1] => yellow
$.[array].[key2][2] => green
$.[array].[key3][0][0] => 1
$.[array].[key3][0][1] => 2
$.[array].[key3][1][0] => 3
$.[array].[key3][1][1] => 4
$.[array].[key3][1][2] => 5
$.[array].[key4][0][0] => 1
$.[array].[key4][0][1] => 2
$.[array].[key4][1][0] => a
$.[array].[key4][1][1] => b
$.[array].[key4][1][2] => c
$.[fruit][0].[name] => apple
$.[fruit][0].[physical].[color] => red
$.[fruit][0].[physical].[shape] => round
$.[fruit][0].[variety][0].[name] => red delicious
$.[fruit][0].[variety][1].[name] => granny smith
$.[fruit][1].[name] => banana
$.[fruit][1].[variety][0].[name] => plantain
```

**Experimental**: Enabled heterogeneous data types in array [originally added in [**TOML v1.0.0-rc.1**](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v1.0.0-rc.1.md)] (will be rolled back with introduction of version rules as per coding standards) :wink:

**Experimental**: Made Tomltype.typeNameFor "public" (useful in some cases) [used in my personal IBM Integration Bus project]