### PR TITLE
Leniently parse dotted key arguments

### DIFF
--- a/src/main/antlr/org/tomlj/internal/TomlLexer.g4
+++ b/src/main/antlr/org/tomlj/internal/TomlLexer.g4
@@ -37,7 +37,9 @@ fragment Digit0_7 : [0-7];
 fragment Digit0_1 : [0-1];
 fragment HexDig : Digit | [A-Fa-f];
 
-fragment UNQUOTED_KEY : (Alpha | Digit | '-' | '_')+;
+fragment KeyChar : (Alpha | Digit | '-' | '_');
+fragment UNQUOTED_KEY : KeyChar+;
+fragment LENIENT_UNQUOTED_KEY : KeyChar | KeyChar (KeyChar | WSChar)* KeyChar;
 
 Dot : '.';
 Equals : '=' { resetArrayDepth(); } -> pushMode(ValueMode);
@@ -65,6 +67,15 @@ KeyUnquotedKey : UNQUOTED_KEY -> type(UnquotedKey);
 KeyWS : WSChar+ -> type(WS), channel(WHITESPACE);
 KeyError : . -> type(Error);
 
+mode TomlKeyMode;
+
+TomlKeyDot : '.' -> type(Dot);
+TomlKeyQuotationMark : '"' -> type(QuotationMark), pushMode(BasicStringMode);
+TomlKeyApostrophe : '\'' -> type(Apostrophe), pushMode(LiteralStringMode);
+TomlKeyUnquotedKey : LENIENT_UNQUOTED_KEY -> type(UnquotedKey);
+
+TomlKeyWS : WSChar+ -> type(WS), channel(WHITESPACE);
+TomlKeyError : . -> type(Error);
 
 mode ValueMode;
 

--- a/src/main/java/org/tomlj/Parser.java
+++ b/src/main/java/org/tomlj/Parser.java
@@ -84,7 +84,7 @@ final class Parser {
 
   static List<String> parseDottedKey(String dottedKey) {
     TomlLexer lexer = new TomlLexer(CharStreams.fromString(dottedKey));
-    lexer.mode(TomlLexer.KeyMode);
+    lexer.mode(TomlLexer.TomlKeyMode);
     TomlParser parser = new TomlParser(new CommonTokenStream(lexer));
     parser.removeErrorListeners();
     AccumulatingErrorListener errorListener = new AccumulatingErrorListener();

--- a/src/test/java/org/tomlj/MutableTomlTableTest.java
+++ b/src/test/java/org/tomlj/MutableTomlTableTest.java
@@ -110,7 +110,7 @@ class MutableTomlTableTest {
   }
 
   @Test
-  void ignoresWhitespaceInUnquotedKeys() {
+  void ignoresWhitespaceAroundUnquotedKeys() {
     MutableTomlTable table = new MutableTomlTable();
     table.set("foo.bar", 4, positionAt(5, 3));
     assertEquals(Long.valueOf(4), table.getLong(" foo . bar"));

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -562,6 +562,26 @@ class TomlTest {
   }
 
   @Test
+  void testSpacesInKeys() throws Exception {
+    TomlParseResult result1 = Toml.parse("\"Dog type\" = \"pug\"");
+    assertFalse(result1.hasErrors(), () -> joinErrors(result1));
+    assertEquals("pug", result1.getString("\"Dog type\""));
+    assertEquals("pug", result1.getString("Dog type"));
+
+    TomlParseResult result2 = Toml.parse("[\"Dog 1\"]\n  type = \"pug\"");
+    assertFalse(result2.hasErrors(), () -> joinErrors(result2));
+    assertEquals("pug", result2.getString("\"Dog 1\".type"));
+    assertEquals("pug", result2.getString("Dog 1.type"));
+
+    TomlParseResult result3 = Toml.parse("[pets.\"Dog 1\"]\n  type = \"pug\"");
+    assertFalse(result3.hasErrors(), () -> joinErrors(result3));
+    assertEquals("pug", result3.getString("pets.\"Dog 1\".type"));
+    assertEquals("pug", result3.getString("pets.Dog 1.type"));
+    assertEquals("pug", result3.getString("pets.Dog 1  .type"));
+    assertEquals("pug", result3.getString("pets.  Dog 1.type"));
+  }
+
+  @Test
   void testQuotesInJson() throws Exception {
     TomlParseResult result1 = Toml.parse("key = \"this is 'a test' with single quotes\"");
     assertFalse(result1.hasErrors());


### PR DESCRIPTION
Use a slightly modified grammar when parsing dotted key arguments, which
allows spaces within the string. Leading and trailing spaces still
require quoting to be considered part of the key.

Resolves #2.