### PR TITLE
Preserve ordering of original TOML document and use when serializing to JSON

### DIFF
--- a/src/main/java/org/tomlj/JsonSerializer.java
+++ b/src/main/java/org/tomlj/JsonSerializer.java
@@ -16,8 +16,8 @@ import static java.util.Objects.requireNonNull;
 import static org.tomlj.TomlType.typeFor;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 
 final class JsonSerializer {
@@ -36,10 +36,11 @@ final class JsonSerializer {
       return;
     }
     appendLine(appendable, "{");
-    for (Iterator<String> iterator = table.keySet().stream().sorted().iterator(); iterator.hasNext();) {
-      String key = iterator.next();
+    for (Iterator<Map.Entry<String, Object>> iterator = table.entrySet().stream().iterator(); iterator.hasNext();) {
+      Map.Entry<String, Object> entry = iterator.next();
+      String key = entry.getKey();
       append(appendable, indent + 2, "\"" + escape(key) + "\" : ");
-      Object value = table.get(Collections.singletonList(key));
+      Object value = entry.getValue();
       assert value != null;
       appendTomlValue(value, appendable, indent);
       if (iterator.hasNext()) {

--- a/src/main/java/org/tomlj/MutableTomlTable.java
+++ b/src/main/java/org/tomlj/MutableTomlTable.java
@@ -15,6 +15,7 @@ package org.tomlj;
 import static org.tomlj.Parser.parseDottedKey;
 import static org.tomlj.TomlType.typeFor;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -87,6 +88,43 @@ final class MutableTomlTable implements TomlTable {
         return Stream.concat(Stream.of(basePath), subKeys);
       } else {
         return subKeys;
+      }
+    }).collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<Entry<String, Object>> entrySet() {
+    return properties
+        .entrySet()
+        .stream()
+        .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().value))
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<Entry<List<String>, Object>> entryPathSet(boolean includeTables) {
+    return properties.entrySet().stream().flatMap(entry -> {
+      String key = entry.getKey();
+      List<String> entryPath = Collections.singletonList(key);
+      Element element = entry.getValue();
+
+      if (!(element.value instanceof TomlTable)) {
+        return Stream.of(new AbstractMap.SimpleEntry<>(entryPath, element.value));
+      }
+
+      Stream<Entry<List<String>, Object>> subEntries =
+          ((TomlTable) element.value).entryPathSet(includeTables).stream().map(subEntry -> {
+            List<String> subPath = subEntry.getKey();
+            List<String> path = new ArrayList<>(subPath.size() + 1);
+            path.add(key);
+            path.addAll(subPath);
+            return new AbstractMap.SimpleEntry<>(path, subEntry.getValue());
+          });
+
+      if (includeTables) {
+        return Stream.concat(Stream.of(new AbstractMap.SimpleEntry<>(entryPath, element.value)), subEntries);
+      } else {
+        return subEntries;
       }
     }).collect(Collectors.toSet());
   }

--- a/src/main/java/org/tomlj/MutableTomlTable.java
+++ b/src/main/java/org/tomlj/MutableTomlTable.java
@@ -18,7 +18,8 @@ import static org.tomlj.TomlType.typeFor;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -40,7 +41,7 @@ final class MutableTomlTable implements TomlTable {
   }
 
   static final TomlTable EMPTY = new MutableTomlTable(true);
-  private final Map<String, Element> properties = new HashMap<>();
+  private final Map<String, Element> properties = new LinkedHashMap<>();
   private boolean implicitlyDefined;
 
   MutableTomlTable() {
@@ -98,7 +99,7 @@ final class MutableTomlTable implements TomlTable {
         .entrySet()
         .stream()
         .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().value))
-        .collect(Collectors.toSet());
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   @Override
@@ -126,7 +127,7 @@ final class MutableTomlTable implements TomlTable {
       } else {
         return subEntries;
       }
-    }).collect(Collectors.toSet());
+    }).collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   @Override

--- a/src/main/java/org/tomlj/Parser.java
+++ b/src/main/java/org/tomlj/Parser.java
@@ -59,6 +59,16 @@ final class Parser {
       }
 
       @Override
+      public Set<Map.Entry<String, Object>> entrySet() {
+        return table.entrySet();
+      }
+
+      @Override
+      public Set<Map.Entry<List<String>, Object>> entryPathSet(boolean includeTables) {
+        return table.entryPathSet(includeTables);
+      }
+
+      @Override
       @Nullable
       public Object get(List<String> path) {
         return table.get(path);

--- a/src/main/java/org/tomlj/TomlTable.java
+++ b/src/main/java/org/tomlj/TomlTable.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -123,6 +124,66 @@ public interface TomlTable {
    * @return A set containing all the key paths of this table.
    */
   Set<List<String>> keyPathSet(boolean includeTables);
+
+  /**
+   * Get the entries of this table.
+   *
+   * <p>
+   * The returned set contains only immediate entries of this table, and not entries with dotted keys or key paths. For
+   * a complete view of all entries available in the TOML document, use {@link #dottedEntrySet()} or
+   * {@link #entryPathSet()}.
+   *
+   * @return A set containing the immediate entries of this table.
+   */
+  Set<Map.Entry<String, Object>> entrySet();
+
+  /**
+   * Get all the dotted entries of this table.
+   *
+   * <p>
+   * Paths to intermediary and empty tables are not returned. To include these, use {@link #dottedEntrySet(boolean)}.
+   *
+   * @return A set containing all the entries of this table.
+   */
+  default Set<Map.Entry<String, Object>> dottedEntrySet() {
+    return entryPathSet()
+        .stream()
+        .map(e -> new AbstractMap.SimpleEntry<>(Toml.joinKeyPath(e.getKey()), e.getValue()))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Get all the dotted entries of this table.
+   *
+   * @param includeTables If {@code true}, also include paths to intermediary and empty tables.
+   * @return A set containing all the entries of this table.
+   */
+  default Set<Map.Entry<String, Object>> dottedEntrySet(boolean includeTables) {
+    return entryPathSet(includeTables)
+        .stream()
+        .map(e -> new AbstractMap.SimpleEntry<>(Toml.joinKeyPath(e.getKey()), e.getValue()))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Get all the entries in this table.
+   *
+   * <p>
+   * Paths to intermediary and empty tables are not returned. To include these, use {@link #entryPathSet(boolean)}.
+   *
+   * @return A set containing all the entries of this table.
+   */
+  default Set<Map.Entry<List<String>, Object>> entryPathSet() {
+    return entryPathSet(false);
+  }
+
+  /**
+   * Get all the entries in this table.
+   *
+   * @param includeTables If {@code true}, also include entries in intermediary and empty tables.
+   * @return A set containing all the entries of this table.
+   */
+  Set<Map.Entry<List<String>, Object>> entryPathSet(boolean includeTables);
 
   /**
    * Get a value from the TOML document.

--- a/src/main/java/org/tomlj/TomlTable.java
+++ b/src/main/java/org/tomlj/TomlTable.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.AbstractMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,7 +93,7 @@ public interface TomlTable {
    * @return A set containing all the dotted keys of this table.
    */
   default Set<String> dottedKeySet() {
-    return keyPathSet().stream().map(Toml::joinKeyPath).collect(Collectors.toSet());
+    return keyPathSet().stream().map(Toml::joinKeyPath).collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   /**
@@ -102,7 +103,10 @@ public interface TomlTable {
    * @return A set containing all the dotted keys of this table.
    */
   default Set<String> dottedKeySet(boolean includeTables) {
-    return keyPathSet(includeTables).stream().map(Toml::joinKeyPath).collect(Collectors.toSet());
+    return keyPathSet(includeTables)
+        .stream()
+        .map(Toml::joinKeyPath)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   /**
@@ -149,7 +153,7 @@ public interface TomlTable {
     return entryPathSet()
         .stream()
         .map(e -> new AbstractMap.SimpleEntry<>(Toml.joinKeyPath(e.getKey()), e.getValue()))
-        .collect(Collectors.toSet());
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   /**
@@ -162,7 +166,7 @@ public interface TomlTable {
     return entryPathSet(includeTables)
         .stream()
         .map(e -> new AbstractMap.SimpleEntry<>(Toml.joinKeyPath(e.getKey()), e.getValue()))
-        .collect(Collectors.toSet());
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   /**

--- a/src/test/java/org/tomlj/MutableTomlTableTest.java
+++ b/src/test/java/org/tomlj/MutableTomlTableTest.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -157,6 +158,46 @@ class MutableTomlTableTest {
         new HashSet<>(Arrays.asList("bar", "foo", "foo.baz", "foo.buz", "foo.buz.bar")),
         table.dottedKeySet(true));
     assertEquals(new HashSet<>(Arrays.asList("bar", "foo.baz", "foo.buz.bar")), table.dottedKeySet());
+  }
+
+  @Test
+  void shouldReturnEntrySet() {
+    MutableTomlTable table = new MutableTomlTable();
+    table.set("bar", "one", positionAt(4, 3));
+    table.set("foo.baz", "two", positionAt(15, 2));
+    assertEquals(
+        new HashSet<>(
+            Arrays
+                .asList(
+                    new AbstractMap.SimpleEntry<>("bar", "one"),
+                    new AbstractMap.SimpleEntry<>("foo", table.get("foo")))),
+        table.entrySet());
+  }
+
+  @Test
+  void shouldReturnDottedEntrySet() {
+    MutableTomlTable table = new MutableTomlTable();
+    table.set("bar", "one", positionAt(4, 3));
+    table.set("foo.baz", "two", positionAt(15, 2));
+    table.set("foo.buz.bar", "three", positionAt(15, 2));
+    assertEquals(
+        new HashSet<>(
+            Arrays
+                .asList(
+                    new AbstractMap.SimpleEntry<>("bar", "one"),
+                    new AbstractMap.SimpleEntry<>("foo", table.get("foo")),
+                    new AbstractMap.SimpleEntry<>("foo.baz", "two"),
+                    new AbstractMap.SimpleEntry<>("foo.buz", table.get("foo.buz")),
+                    new AbstractMap.SimpleEntry<>("foo.buz.bar", "three"))),
+        table.dottedEntrySet(true));
+    assertEquals(
+        new HashSet<>(
+            Arrays.<AbstractMap
+                .SimpleEntry<String, Object>>asList(
+                    new AbstractMap.SimpleEntry<>("bar", "one"),
+                    new AbstractMap.SimpleEntry<>("foo.baz", "two"),
+                    new AbstractMap.SimpleEntry<>("foo.buz.bar", "three"))),
+        table.dottedEntrySet());
   }
 
   @Test

--- a/src/test/java/org/tomlj/MutableTomlTableTest.java
+++ b/src/test/java/org/tomlj/MutableTomlTableTest.java
@@ -216,20 +216,20 @@ class MutableTomlTableTest {
     table.set("zoo", LocalDate.parse("1937-07-18"), positionAt(5, 2));
     table.set("alpha", LocalTime.parse("03:25:43"), positionAt(5, 2));
     String expected = "{\n"
-        + "  \"alpha\" : \"03:25:43\",\n"
         + "  \"bar\" : \"one\",\n"
-        + "  \"buz\" : \"1937-07-18T03:25:43-04:00\",\n"
         + "  \"foo\" : {\n"
         + "    \"baz\" : \"two\",\n"
+        + "    \"buz\" : [],\n"
+        + "    \"foo\" : {},\n"
         + "    \"blah\" : [\n"
         + "      \"hello\\nthere\",\n"
         + "      \"goodbye\"\n"
-        + "    ],\n"
-        + "    \"buz\" : [],\n"
-        + "    \"foo\" : {}\n"
+        + "    ]\n"
         + "  },\n"
+        + "  \"buz\" : \"1937-07-18T03:25:43-04:00\",\n"
         + "  \"glad\" : \"1937-07-18T03:25:43\",\n"
-        + "  \"zoo\" : \"1937-07-18\"\n"
+        + "  \"zoo\" : \"1937-07-18\",\n"
+        + "  \"alpha\" : \"03:25:43\"\n"
         + "}\n";
     assertEquals(expected.replace("\n", System.lineSeparator()), table.toJson());
   }

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -26,6 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Scanner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -601,6 +602,19 @@ class TomlTest {
     TomlParseResult result1 = Toml.parse("path = 'C:\\Users\\dog\\catsihate'");
     assertFalse(result1.hasErrors(), () -> joinErrors(result1));
     assertEquals("{\n  \"path\" : \"C:\\\\Users\\\\dog\\\\catsihate\"\n}\n", result1.toJson());
+  }
+
+  @Test
+  void testOrderPreservationInJson() throws Exception {
+    String expectedJson =
+        new Scanner(this.getClass().getResourceAsStream("/org/tomlj/toml-v0.5.0-spec-example.json"), "UTF-8")
+            .useDelimiter("\\A")
+            .next();;
+    InputStream is = this.getClass().getResourceAsStream("/org/tomlj/toml-v0.5.0-spec-example.toml");
+    assertNotNull(is);
+    TomlParseResult result = Toml.parse(is);
+    assertFalse(result.hasErrors(), () -> joinErrors(result));
+    assertEquals(expectedJson, result.toJson());
   }
 
   private String joinErrors(TomlParseResult result) {

--- a/src/test/resources/org/tomlj/toml-v0.5.0-spec-example.json
+++ b/src/test/resources/org/tomlj/toml-v0.5.0-spec-example.json
@@ -1,0 +1,43 @@
+{
+  "title" : "TOML Example",
+  "owner" : {
+    "name" : "Tom Preston-Werner",
+    "dob" : "1979-05-27T07:32-08:00"
+  },
+  "database" : {
+    "server" : "192.168.1.1",
+    "ports" : [
+      8001,
+      8001,
+      8002
+    ],
+    "connection_max" : 5000,
+    "enabled" : true
+  },
+  "servers" : {
+    "alpha" : {
+      "ip" : "10.0.0.1",
+      "dc" : "eqdc10"
+    },
+    "beta" : {
+      "ip" : "10.0.0.2",
+      "dc" : "eqdc10"
+    }
+  },
+  "clients" : {
+    "data" : [
+      [
+        "gamma",
+        "delta"
+      ],
+      [
+        1,
+        2
+      ]
+    ],
+    "hosts" : [
+      "alpha",
+      "omega"
+    ]
+  }
+}


### PR DESCRIPTION
Also add `TomlTable#entrySet()` and related methods, which allow iterating over pairs of keys & values concurrently (rather than iterating over keys and then retrieving each value).