### PR TITLE
Toml writer

### DIFF
--- a/src/main/java/org/tomlj/QuotedStringVisitor.java
+++ b/src/main/java/org/tomlj/QuotedStringVisitor.java
@@ -68,6 +68,8 @@ final class QuotedStringVisitor extends TomlParserBaseVisitor<StringBuilder> {
       return builder.append('\\');
     }
     switch (text.charAt(1)) {
+      case '\'':
+        return builder.append('\'');
       case '"':
         return builder.append('"');
       case '\\':

--- a/src/main/java/org/tomlj/Toml.java
+++ b/src/main/java/org/tomlj/Toml.java
@@ -216,6 +216,14 @@ public final class Toml {
         out.append("\\'");
         continue;
       }
+      if (ch == '\"') {
+        out.append("\\\"");
+        continue;
+      }
+      if (ch == '\\') {
+        out.append("\\\\");
+        continue;
+      }
       if (ch >= 0x20 && ch < 0x7F) {
         out.append(ch);
         continue;

--- a/src/main/java/org/tomlj/TomlArray.java
+++ b/src/main/java/org/tomlj/TomlArray.java
@@ -309,4 +309,30 @@ public interface TomlArray {
   default void toJson(Appendable appendable) throws IOException {
     JsonSerializer.toJson(this, appendable);
   }
+
+  /**
+   * Return a representation of this array using TOML.
+   *
+   * @return A TOML representation of this array.
+   */
+  default String toToml() {
+    StringBuilder builder = new StringBuilder();
+    try {
+      toToml(builder);
+    } catch (IOException e) {
+      // not reachable
+      throw new UncheckedIOException(e);
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Append a TOML representation of this array to the appendable output.
+   *
+   * @param appendable The appendable output.
+   * @throws IOException If an IO error occurs.
+   */
+  default void toToml(Appendable appendable) throws IOException {
+    TomlSerializer.toToml(this, appendable);
+  }
 }

--- a/src/main/java/org/tomlj/TomlSerializer.java
+++ b/src/main/java/org/tomlj/TomlSerializer.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.tomlj;
+
+import static java.util.Objects.requireNonNull;
+import static org.tomlj.TomlType.ARRAY;
+import static org.tomlj.TomlType.TABLE;
+import static org.tomlj.TomlType.typeFor;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+
+final class TomlSerializer {
+  private TomlSerializer() {}
+
+  static void toToml(TomlTable table, Appendable appendable) throws IOException {
+    requireNonNull(table);
+    requireNonNull(appendable);
+    toToml(table, appendable, -2, "");
+  }
+
+  private static void toToml(TomlTable table, Appendable appendable, int indent, String path)
+      throws IOException {
+    for (Map.Entry<String, Object> entry : table.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+
+      key = Toml.tomlEscape(key).toString();
+      if (!key.matches("[a-zA-Z0-9_-]*")) {
+        key = "\"" + key + "\"";
+      }
+
+      String newPath = (path.isEmpty() ? "" : path + ".") + key;
+
+      Optional<TomlType> tomlType = typeFor(value);
+      assert tomlType.isPresent();
+
+      boolean isTableArray = tomlType.get().equals(ARRAY) && isTableArray((TomlArray) value);
+
+      if (tomlType.get().equals(TABLE)) {
+        append(appendable, indent + 2, "[" + newPath + "]");
+        appendable.append(System.lineSeparator());
+      } else if (!isTableArray) {
+        append(appendable, indent + 2, key + "=");
+      }
+
+      assert value != null;
+      appendTomlValue(value, appendable, indent, newPath);
+      if (!tomlType.get().equals(TABLE) && !isTableArray) {
+        appendable.append(System.lineSeparator());
+      }
+    }
+  }
+
+  static void toToml(TomlArray array, Appendable appendable) throws IOException {
+    requireNonNull(array);
+    requireNonNull(appendable);
+    toToml(array, appendable, 0, "");
+  }
+
+  private static void toToml(TomlArray array, Appendable appendable, int indent, String path)
+      throws IOException {
+    boolean tableArray = isTableArray(array);
+    if (!tableArray) {
+      appendable.append("[");
+      if (!array.isEmpty()) {
+        appendable.append(System.lineSeparator());
+      }
+    }
+
+    Optional<TomlType> tomlType = Optional.empty();
+    for (Iterator<Object> iterator = array.toList().iterator(); iterator.hasNext(); ) {
+      Object tomlValue = iterator.next();
+      tomlType = typeFor(tomlValue);
+      assert tomlType.isPresent();
+      if (tomlType.get().equals(TABLE)) {
+        append(appendable, indent, "[[" + path + "]]");
+        appendable.append(System.lineSeparator());
+        toToml((TomlTable) tomlValue, appendable, indent, path);
+      } else {
+        indentLine(appendable, indent + 2);
+        appendTomlValue(tomlValue, appendable, indent, path);
+      }
+
+      if (!tableArray) {
+        if (iterator.hasNext()) {
+          appendable.append(",");
+        }
+        appendable.append(System.lineSeparator());
+      }
+    }
+    if (!tableArray) {
+      append(appendable, indent, "]");
+    }
+  }
+
+  private static void appendTomlValue(Object value, Appendable appendable, int indent, String path)
+      throws IOException {
+    Optional<TomlType> tomlType = typeFor(value);
+    assert tomlType.isPresent();
+    switch (tomlType.get()) {
+      case STRING:
+        append(appendable, 0, "\"" + Toml.tomlEscape((String) value) + "\"");
+        break;
+      case INTEGER:
+      case FLOAT:
+        append(appendable, 0, value.toString());
+        break;
+      case OFFSET_DATE_TIME:
+        append(
+            appendable, 0, DateTimeFormatter.ISO_OFFSET_DATE_TIME.format((OffsetDateTime) value));
+        break;
+      case LOCAL_DATE_TIME:
+        append(appendable, 0, DateTimeFormatter.ISO_LOCAL_DATE_TIME.format((LocalDateTime) value));
+        break;
+      case LOCAL_DATE:
+        append(appendable, 0, DateTimeFormatter.ISO_LOCAL_DATE.format((LocalDate) value));
+        break;
+      case LOCAL_TIME:
+        append(appendable, 0, DateTimeFormatter.ISO_LOCAL_TIME.format((LocalTime) value));
+        break;
+      case BOOLEAN:
+        append(appendable, 0, ((Boolean) value) ? "true" : "false");
+        break;
+      case ARRAY:
+        toToml((TomlArray) value, appendable, indent + 2, path);
+        break;
+      case TABLE:
+        toToml((TomlTable) value, appendable, indent + 2, path);
+        break;
+    }
+  }
+
+  private static void append(Appendable appendable, int indent, String line) throws IOException {
+    indentLine(appendable, indent);
+    appendable.append(line);
+  }
+
+  private static void indentLine(Appendable appendable, int indent) throws IOException {
+    for (int i = 0; i < indent; ++i) {
+      appendable.append(' ');
+    }
+  }
+
+  private static boolean isTableArray(TomlArray array) {
+    Optional<TomlType> tomlType = Optional.empty();
+    for (Object tomlValue : array.toList()) {
+      tomlType = typeFor(tomlValue);
+      assert tomlType.isPresent();
+      if (tomlType.get().equals(TABLE)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/tomlj/TomlTable.java
+++ b/src/main/java/org/tomlj/TomlTable.java
@@ -1239,4 +1239,30 @@ public interface TomlTable {
   default void toJson(Appendable appendable) throws IOException {
     JsonSerializer.toJson(this, appendable);
   }
+
+  /**
+   * Return a representation of this table using TOML.
+   *
+   * @return A TOML representation of this table.
+   */
+  default String toToml() {
+    StringBuilder builder = new StringBuilder();
+    try {
+      toToml(builder);
+    } catch (IOException e) {
+      // not reachable
+      throw new UncheckedIOException(e);
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Append a TOML representation of this table to the appendable output.
+   *
+   * @param appendable The appendable output.
+   * @throws IOException If an IO error occurs.
+   */
+  default void toToml(Appendable appendable) throws IOException {
+    TomlSerializer.toToml(this, appendable);
+  }
 }

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -21,7 +21,9 @@ import static org.tomlj.TomlType.ARRAY;
 import static org.tomlj.TomlType.TABLE;
 import static org.tomlj.TomlType.typeFor;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -753,6 +755,21 @@ class TomlTest {
     TomlParseResult result = Toml.parse(is);
     assertFalse(result.hasErrors(), () -> joinErrors(result));
     assertEquals(expectedJson.replace("\n", System.lineSeparator()), result.toJson());
+  }
+
+  @Test
+  void testSerializerArrayTables() throws Exception {
+    InputStream is = this.getClass().getResourceAsStream("/org/tomlj/array_table_example.toml");
+    assertNotNull(is);
+    TomlParseResult result = Toml.parse(is);
+    assertFalse(result.hasErrors(), () -> joinErrors(result));
+
+    String serializedToml = result.toToml();
+    TomlParseResult resultReparse =
+        Toml.parse(new ByteArrayInputStream(serializedToml.getBytes(StandardCharsets.UTF_8)));
+    assertFalse(resultReparse.hasErrors(), () -> joinErrors(result));
+
+    assertTrue(tableEquals(result, resultReparse));
   }
 
   private String joinErrors(TomlParseResult result) {

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -772,6 +772,21 @@ class TomlTest {
     assertTrue(tableEquals(result, resultReparse));
   }
 
+  @Test
+  void testSerializerHardExample() throws Exception {
+    InputStream is = this.getClass().getResourceAsStream("/org/tomlj/hard_example.toml");
+    assertNotNull(is);
+    TomlParseResult result = Toml.parse(is);
+    assertFalse(result.hasErrors(), () -> joinErrors(result));
+
+    String serializedToml = result.toToml();
+    TomlParseResult resultReparse =
+        Toml.parse(new ByteArrayInputStream(serializedToml.getBytes(StandardCharsets.UTF_8)));
+    assertFalse(resultReparse.hasErrors(), () -> joinErrors(result));
+
+    assertTrue(tableEquals(result, resultReparse));
+  }
+
   private String joinErrors(TomlParseResult result) {
     return result.errors().stream().map(TomlParseError::toString).collect(Collectors.joining("\n"));
   }


### PR DESCRIPTION
I created a Toml serializer implementation based on the `JsonSerializer` class.
One can use the `toToml()` method of either the `TomlTable` or the `TomlArray` class.

I tested it and it worked for my test cases but it still may not be perfect.
I could add a unit test if needed.

This should solve #16 .
