### PR TITLE
Feature: Allow throw TomlParseError

### DIFF
--- a/src/main/java/org/tomlj/LineVisitor.java
+++ b/src/main/java/org/tomlj/LineVisitor.java
@@ -26,11 +26,14 @@ final class LineVisitor extends TomlParserBaseVisitor<MutableTomlTable> {
   private final MutableTomlTable table;
   private MutableTomlTable currentTable;
 
-  LineVisitor(TomlVersion version, ErrorReporter errorReporter) {
+  private boolean throwException;
+
+  LineVisitor(TomlVersion version, ErrorReporter errorReporter, boolean throwException) {
     this.version = version;
     this.errorReporter = errorReporter;
     this.table = new MutableTomlTable(version);
     this.currentTable = table;
+    this.throwException = throwException;
   }
 
   @Override
@@ -55,7 +58,10 @@ final class LineVisitor extends TomlParserBaseVisitor<MutableTomlTable> {
       }
       return table;
     } catch (TomlParseError e) {
-      errorReporter.reportError(e);
+      if (throwException)
+        throw new TomlDuplicatedKeyException(e);
+      else
+        errorReporter.reportError(e);
       return table;
     }
   }
@@ -74,7 +80,10 @@ final class LineVisitor extends TomlParserBaseVisitor<MutableTomlTable> {
     try {
       currentTable = table.createTable(path, new TomlPosition(ctx));
     } catch (TomlParseError e) {
-      errorReporter.reportError(e);
+      if (throwException)
+        throw new TomlDuplicatedKeyException(e);
+      else
+        errorReporter.reportError(e);
     }
     return table;
   }
@@ -93,7 +102,10 @@ final class LineVisitor extends TomlParserBaseVisitor<MutableTomlTable> {
     try {
       currentTable = table.createTableArray(path, new TomlPosition(ctx));
     } catch (TomlParseError e) {
-      errorReporter.reportError(e);
+      if (throwException)
+        throw new TomlDuplicatedKeyException(e);
+      else
+        errorReporter.reportError(e);
     }
     return table;
   }

--- a/src/main/java/org/tomlj/Parser.java
+++ b/src/main/java/org/tomlj/Parser.java
@@ -28,14 +28,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class Parser {
   private Parser() {}
 
-  static TomlParseResult parse(CharStream stream, TomlVersion version) {
+  static TomlParseResult parse(CharStream stream, TomlParseSettings settings) {
     TomlLexer lexer = new TomlLexer(stream);
     TomlParser parser = new TomlParser(new CommonTokenStream(lexer));
     parser.removeErrorListeners();
     AccumulatingErrorListener errorListener = new AccumulatingErrorListener();
     parser.addErrorListener(errorListener);
     ParseTree tree = parser.toml();
-    TomlTable table = tree.accept(new LineVisitor(version, errorListener));
+    LineVisitor visitor = new LineVisitor(settings.tomlVersion.canonical, errorListener, settings.throwParseException);
+    TomlTable table = tree.accept(visitor);
 
     return new TomlParseResult() {
       @Override

--- a/src/main/java/org/tomlj/Toml.java
+++ b/src/main/java/org/tomlj/Toml.java
@@ -41,19 +41,19 @@ public final class Toml {
    * @return The parse result.
    */
   public static TomlParseResult parse(String input) {
-    return parse(input, TomlVersion.LATEST);
+    return parse(input, TomlParseSettings.DEFAULT);
   }
 
   /**
    * Parse a TOML string.
    *
    * @param input The input to parse.
-   * @param version The version level to parse at.
+   * @param settings The parse settings.
    * @return The parse result.
    */
-  public static TomlParseResult parse(String input, TomlVersion version) {
+  public static TomlParseResult parse(String input, TomlParseSettings settings) {
     CharStream stream = CharStreams.fromString(input);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, settings);
   }
 
   /**
@@ -64,20 +64,20 @@ public final class Toml {
    * @throws IOException If an IO error occurs.
    */
   public static TomlParseResult parse(Path file) throws IOException {
-    return parse(file, TomlVersion.LATEST);
+    return parse(file, TomlParseSettings.DEFAULT);
   }
 
   /**
    * Parse a TOML file.
    *
    * @param file The input file to parse.
-   * @param version The version level to parse at.
+   * @param settings The parse settings.
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(Path file, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(Path file, TomlParseSettings settings) throws IOException {
     CharStream stream = CharStreams.fromPath(file);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, settings);
   }
 
   /**
@@ -88,20 +88,20 @@ public final class Toml {
    * @throws IOException If an IO error occurs.
    */
   public static TomlParseResult parse(InputStream is) throws IOException {
-    return parse(is, TomlVersion.LATEST);
+    return parse(is, TomlParseSettings.DEFAULT);
   }
 
   /**
    * Parse a TOML input stream.
    *
    * @param is The input stream to read the TOML document from.
-   * @param version The version level to parse at.
+   * @param settings The parse settings.
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(InputStream is, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(InputStream is, TomlParseSettings settings) throws IOException {
     CharStream stream = CharStreams.fromStream(is);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, settings);
   }
 
   /**
@@ -112,20 +112,20 @@ public final class Toml {
    * @throws IOException If an IO error occurs.
    */
   public static TomlParseResult parse(Reader reader) throws IOException {
-    return parse(reader, TomlVersion.LATEST);
+    return parse(reader, TomlParseSettings.DEFAULT);
   }
 
   /**
    * Parse a TOML input stream.
    *
    * @param reader The reader to obtain the TOML document from.
-   * @param version The version level to parse at.
+   * @param settings The parse settings.
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(Reader reader, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(Reader reader, TomlParseSettings settings) throws IOException {
     CharStream stream = CharStreams.fromReader(reader);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, settings);
   }
 
   /**
@@ -136,20 +136,20 @@ public final class Toml {
    * @throws IOException If an IO error occurs.
    */
   public static TomlParseResult parse(ReadableByteChannel channel) throws IOException {
-    return parse(channel, TomlVersion.LATEST);
+    return parse(channel, TomlParseSettings.DEFAULT);
   }
 
   /**
    * Parse a TOML input stream.
    *
    * @param channel The channel to read the TOML document from.
-   * @param version The version level to parse at.
+   * @param settings The parse settings.
    * @return The parse result.
    * @throws IOException If an IO error occurs.
    */
-  public static TomlParseResult parse(ReadableByteChannel channel, TomlVersion version) throws IOException {
+  public static TomlParseResult parse(ReadableByteChannel channel, TomlParseSettings settings) throws IOException {
     CharStream stream = CharStreams.fromChannel(channel);
-    return Parser.parse(stream, version.canonical);
+    return Parser.parse(stream, settings);
   }
 
   /**

--- a/src/main/java/org/tomlj/TomlDuplicatedKeyException.java
+++ b/src/main/java/org/tomlj/TomlDuplicatedKeyException.java
@@ -1,0 +1,13 @@
+package org.tomlj;
+
+public class TomlDuplicatedKeyException extends TomlParseError {
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return null;
+    }
+
+    TomlDuplicatedKeyException(TomlParseError cause) {
+        super(cause.getMessage(), cause.position(), cause);
+    }
+}

--- a/src/main/java/org/tomlj/TomlParseError.java
+++ b/src/main/java/org/tomlj/TomlParseError.java
@@ -16,7 +16,7 @@ package org.tomlj;
  * An error that occurred while parsing.
  */
 @SuppressWarnings("OverrideThrowableToString")
-public final class TomlParseError extends RuntimeException {
+public class TomlParseError extends RuntimeException {
 
   private final TomlPosition position;
 

--- a/src/main/java/org/tomlj/TomlParseSettings.java
+++ b/src/main/java/org/tomlj/TomlParseSettings.java
@@ -1,0 +1,13 @@
+package org.tomlj;
+
+public class TomlParseSettings {
+    TomlVersion tomlVersion;
+    boolean throwParseException;
+
+    static TomlParseSettings DEFAULT = new TomlParseSettings(TomlVersion.LATEST, false);
+
+    public TomlParseSettings(TomlVersion tomlVersion, boolean throwParseException) {
+        this.tomlVersion = tomlVersion;
+        this.throwParseException = throwParseException;
+    }
+}

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -681,7 +681,9 @@ class TomlTest {
     assertNotNull(is);
     TomlParseResult result = Toml.parse(is);
     assertFalse(result.hasErrors(), () -> joinErrors(result));
-    assertEquals(expectedJson.replace("\n", System.lineSeparator()), result.toJson());
+    String expected = expectedJson.replace(System.lineSeparator(), "\n");
+    String actual = result.toJson().replace(System.lineSeparator(), "\n");
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -750,7 +752,9 @@ class TomlTest {
     assertNotNull(is);
     TomlParseResult result = Toml.parse(is);
     assertFalse(result.hasErrors(), () -> joinErrors(result));
-    assertEquals(expectedJson.replace("\n", System.lineSeparator()), result.toJson());
+    String expected = expectedJson.replace(System.lineSeparator(), "\n");
+    String actual = result.toJson().replace(System.lineSeparator(), "\n");
+    assertEquals(expected, actual);
   }
 
   @Test


### PR DESCRIPTION
Sorry I submitted this PR without discussing it first, please feel free to close it if it looks bad :)

There are two commits in this PR.
1. Fix tests failing on Windows
2. Allow throw TomlParseError to close #39 