### PR TITLE
Allow Incremental Lexing

### DIFF
--- a/src/main/antlr/org/tomlj/internal/TomlLexer.g4
+++ b/src/main/antlr/org/tomlj/internal/TomlLexer.g4
@@ -9,8 +9,8 @@ package org.tomlj.internal;
 }
 
 @members {
-  private final IntegerStack arrayDepthStack = new IntegerStack();
-  private int arrayDepth = 0;
+  public final IntegerStack arrayDepthStack = new IntegerStack();
+  public int arrayDepth = 0;
 
   private void resetArrayDepth() {
     arrayDepthStack.clear();

--- a/src/main/antlr/org/tomlj/internal/TomlLexer.g4
+++ b/src/main/antlr/org/tomlj/internal/TomlLexer.g4
@@ -9,6 +9,7 @@ package org.tomlj.internal;
 }
 
 @members {
+  // State is made public to allow incremental lexers to save and restore it (e.g. NetBeans)
   public final IntegerStack arrayDepthStack = new IntegerStack();
   public int arrayDepth = 0;
 


### PR DESCRIPTION
I've recently added TOML Support to NetBeans IDE using this library.

From time to time I receive an indexOutOfBoundsException. For performance reasons NetBeans does incremental lexing.
That means when editing a TOML file, the Lexing would start from the last token, restoring the Lexer internal state. That's fine as the internal state of the underlying Antlr4 Lexer is public. But right now I can only do that using reflection.