### PR TITLE
build.gradle: Set source encoding to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,10 @@ configurations {
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
+
 jacoco { toolVersion = '0.8.7' }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Set the source encoding to UTF-8.

This fixes some problems on Windows where the character set was incorrectly assumed:
https://github.com/tomlj/tomlj/blob/85bd0283a4e120f77f4c6f13e7cdb5dce875f66d/src/test/java/org/tomlj/TomlTest.java#L726
