### PR TITLE
Toml serializer nested table fix

### DIFF
--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -737,6 +737,28 @@ class TomlTest {
   }
 
   @Test
+  void testCrateExample() throws Exception {
+    InputStream is = this.getClass().getResourceAsStream("/org/tomlj/crate-example.toml");
+    assertNotNull(is);
+    TomlParseResult result = Toml.parse(is, TomlVersion.V0_4_0);
+    assertFalse(result.hasErrors(), () -> joinErrors(result));
+
+    assertEquals("a fun test case", result.getString("package.name"));
+    assertEquals("=0.99.17", result.getString("dependencies.derive_more.version"));
+
+    String serializedToml = result.toToml();
+
+    TomlParseResult resultReparse =
+        Toml.parse(new ByteArrayInputStream(serializedToml.getBytes(StandardCharsets.UTF_8)));
+    assertFalse(resultReparse.hasErrors(), () -> joinErrors(result));
+
+    serializedToml = resultReparse.toToml();
+    System.out.println(serializedToml);
+
+    assertTrue(Toml.equals(result, resultReparse));
+  }
+
+  @Test
   void testSpecExample() throws Exception {
     InputStream is = this.getClass().getResourceAsStream("/org/tomlj/toml-v0.5.0-spec-example.toml");
     assertNotNull(is);

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -745,6 +745,7 @@ class TomlTest {
 
     assertEquals("a fun test case", result.getString("package.name"));
     assertEquals("=0.99.17", result.getString("dependencies.derive_more.version"));
+    assertEquals("FUN", result.getString("dependencies.alias"));
 
     String serializedToml = result.toToml();
 

--- a/src/test/resources/org/tomlj/crate-example.toml
+++ b/src/test/resources/org/tomlj/crate-example.toml
@@ -5,7 +5,10 @@ edition         = "2021"
 license         = "MIT"
 
 [dependencies]
-derive_more     = { version = "=0.99.17", features = ["deref"] }
-serde_with      = "=2.3.1"
-strum           = { version = "=0.24", features = ["derive"] }
+derive_more       = { version = "=0.99.17", features = ["deref"] }
+serde_with        = "=2.3.1"
+random_objects    = [{name="random1", import="all"}, {name="random2", import="shallow"}]
+alias             = "FUN"
+accepted_versions = ["1.11", "1.12"]
+strum             = { version = "=0.24", features = ["derive"] }
 

--- a/src/test/resources/org/tomlj/crate-example.toml
+++ b/src/test/resources/org/tomlj/crate-example.toml
@@ -1,0 +1,11 @@
+[package]
+name            = "a fun test case"
+version         = "0.0.0-SNAPSHOT"
+edition         = "2021"
+license         = "MIT"
+
+[dependencies]
+derive_more     = { version = "=0.99.17", features = ["deref"] }
+serde_with      = "=2.3.1"
+strum           = { version = "=0.24", features = ["derive"] }
+


### PR DESCRIPTION
When serializing Toml, in tables, nested tables and table arrays are sorted so that primitive values appear as preceding them.

Solves #57