### PR TITLE
Fix issue with array trailing commas

### DIFF
--- a/src/main/antlr/org/tomlj/internal/TomlLexer.g4
+++ b/src/main/antlr/org/tomlj/internal/TomlLexer.g4
@@ -110,7 +110,8 @@ ValueDateStart : Digit+ { "-:".indexOf(_input.LA(1)) >= 0 }? -> type(DateDigits)
 // Array
 ArrayStart : '[' { arrayDepth++; } -> pushMode(ValueMode);
 ArrayEnd : ']' { arrayDepth--; } -> popMode;
-ArrayComma : ',' { arrayDepth > 0 }? -> type(Comma), pushMode(ValueMode);
+ArrayComma : ',' { arrayDepth > 0 && _input.LA(1) != ']' }? -> type(Comma), pushMode(ValueMode);
+ArrayTrailingComma : ',' (NL|WSChar)* { arrayDepth > 0 && _input.LA(1) == ']' }? -> type(Comma);
 
 // Table
 InlineTableStart : '{' { pushArrayDepth(); } -> mode(InlineTableMode);

--- a/src/test/java/org/tomlj/TomlTest.java
+++ b/src/test/java/org/tomlj/TomlTest.java
@@ -517,6 +517,31 @@ class TomlTest {
   }
 
   @ParameterizedTest
+  @MethodSource("arrayWithTrailingCommaWithinInlineTableSupplier")
+  void shouldParseArrayWithTrailingCommaWithinInlineTable(String input, Object[] expected) {
+    TomlParseResult result = Toml.parse(input);
+    assertFalse(result.hasErrors(), () -> joinErrors(result));
+    TomlArray array = result.getArray("foo.bar");
+    assertNotNull(array);
+    assertEquals(expected.length, array.size());
+    assertTomlArrayEquals(expected, array);
+  }
+
+  static Stream<Arguments> arrayWithTrailingCommaWithinInlineTableSupplier() {
+    // @formatter:off
+    return Stream.of(
+            Arguments.of("foo = { bar = ['baz'] , buz = 2 }", new Object[] {"baz"}),
+            Arguments.of("foo = { bar = ['baz',] , buz = 2 }", new Object[] {"baz"}),
+            Arguments.of("foo = { bar = ['baz', ] , buz = 2 }", new Object[] {"baz"}),
+            Arguments.of("foo = { bar = ['baz',\n] , buz = 2 }", new Object[] {"baz"}),
+            Arguments.of("foo = { bar = ['baz', \n ] , buz = 2 }", new Object[] {"baz"}),
+            Arguments.of("foo = { bar = ['baz',\n \n] , buz = 2 }", new Object[] {"baz"}),
+            Arguments.of("foo = { bar = ['baz'\n \n,] , buz = 2 }", new Object[] {"baz"})
+    );
+    // @formatter:on
+  }
+
+  @ParameterizedTest
   @MethodSource("arrayTableSupplier")
   void shouldParseArrayTable(String input, Object[] path, Object expected) {
     TomlParseResult result = Toml.parse(input);


### PR DESCRIPTION
Add a new rule, ArrayTrailingComma, which avoids pushing ValueMode onto the stack if the comma is trailing. It looks ahead and checks if the next input in the stream is ']'.

Fixes #60 